### PR TITLE
Fix the compilation of the OCaml toolchain and specify the right target value according to how we want to compile with solo5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ ocaml/Makefile.config: ocaml/Makefile openlibm/libopenlibm.a nolibc/libnolibc.a
 		ac_cv_prog_DIRECT_LD="$(MAKECONF_LD)" \
 		ac_cv_lib_m_cos="no" \
 	  ./configure \
-		-host=$(MAKECONF_BUILD_ARCH)-unknown-none \
+		-host=$(MAKECONF_ARCH)-unknown-none \
+		-target=$(MAKECONF_BUILD_ARCH)-solo5-none \
 		-prefix $(MAKECONF_PREFIX)/solo5-sysroot \
 		-disable-shared\
 		-disable-systhreads\

--- a/configure.sh
+++ b/configure.sh
@@ -31,6 +31,8 @@ EOM
 
 OCAML_CONFIGURE_OPTIONS=
 MAKECONF_PREFIX=/usr/local
+CC=cc
+
 while [ $# -gt 0 ]; do
     OPT="$1"
 
@@ -78,7 +80,22 @@ case "${BUILD_TRIPLET}" in
         OCAML_BUILD_ARCH="arm64"
         ;;
     *)
-        die "Unsupported architecture: ${BUILD_TRIPLET}"
+        die "Unsupported build architecture: ${BUILD_TRIPLET}"
+        ;;
+esac
+
+TRIPLET="$($CC -dumpmachine)"
+ARCH=
+
+case "${TRIPLET}" in
+    amd64-*|x86_64-*)
+        ARCH="x86_64"
+        ;;
+    aarch64-*)
+        ARCH="aarch64"
+        ;;
+    *)
+        die "Unsupported host architecture: ${TRIPLET}"
         ;;
 esac
 
@@ -94,6 +111,7 @@ MAKECONF_TOOLCHAIN=${CONFIG_TARGET}
 MAKECONF_CC=${MAKECONF_CC}
 MAKECONF_LD=${MAKECONF_LD}
 MAKECONF_AS=${MAKECONF_AS}
+MAKECONF_ARCH=${ARCH}
 MAKECONF_BUILD_ARCH=${BUILD_ARCH}
 MAKECONF_OCAML_BUILD_ARCH=${OCAML_BUILD_ARCH}
 MAKECONF_OCAML_CONFIGURE_OPTIONS=${OCAML_CONFIGURE_OPTIONS}


### PR DESCRIPTION
Spotted by `bob` and `esperanto`, we currently don't really specify the right target (at least, the architecture of it) which is needed by some packages like `ocaml-gmp` to be able to cross-compile artifacts to the right assembler. This patch want to clarify that and allows us to really cross-compile a project to `aarch64`. It was not spotted because we never tried to use `ocaml-solo5` as a real cross-compiler for `aarch64` for larger projects.