### PR TITLE
Update the opam Synopsis, to mention Solo5

### DIFF
--- a/ocaml-solo5-cross-aarch64.opam
+++ b/ocaml-solo5-cross-aarch64.opam
@@ -37,6 +37,6 @@ available: [
   | (os = "freebsd" & arch = "x86_64")
   | (os = "openbsd" & arch = "x86_64"))
 ]
-synopsis: "Freestanding OCaml compiler"
+synopsis: "OCaml cross-compiler to the freestanding 64-bit ARM Solo5 backend"
 description:
   "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."

--- a/ocaml-solo5.opam
+++ b/ocaml-solo5.opam
@@ -36,6 +36,6 @@ available: [
   | (os = "freebsd" & arch = "x86_64")
   | (os = "openbsd" & arch = "x86_64"))
 ]
-synopsis: "Freestanding OCaml compiler"
+synopsis: "OCaml cross-compiler to the freestanding Solo5 backend"
 description:
   "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."


### PR DESCRIPTION
The packages have been renamed from ocaml-freestanding* into ocaml-solo5* but their synopses have not been updated accordingly.