### PR TITLE
Make the mode appear clearly in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
             mode:
               name: spt
               exec: true
+    name: ${{ matrix.mode.name }} / ${{ matrix.ocaml-version }}
     runs-on: ${{ matrix.operating-system }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR is a small quality-of-life improvement, by making the mode standout in CI results, as I have been repeatedly looking for the `spt` mode to make sure the test ran without any surprising log (I suspect the logs of the other modes are not much more informative than just their success result, when successful).