### PR TITLE
CI: Update the FreeBSD version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-1
+  image_family: freebsd-14-2
 
 freebsd_task:
   env:


### PR DESCRIPTION
The FreeBSD 14 image provided on the CI machines has changed to 14.2. I didn’t find a way to ask simply for the latest version though.