### PR TITLE
Show up for logs how we apply patches when we install ocaml-solo5 via opam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,10 @@ ocaml:
 	cp -r "$$(ocamlfind query ocaml-src)" $@
 	VERSION="$$(head -n1 ocaml/VERSION)" ; \
 	if test -d "patches/$$VERSION" ; then \
-	  git apply --directory=$@ "patches/$$VERSION"/*; \
+	  for p in "patches/$$VERSION"/*; do \
+	    ( set -x ; git apply -v --directory=$@ "$$p" \
+	    ; echo " PATCH $$p: $$?") ; \
+	  done ; \
 	fi
 
 ocaml/Makefile.config: $(LIBS) $(TOOLCHAIN_FOR_BUILD) | ocaml


### PR DESCRIPTION
This patch does not change many things but it seems to fix the installation of `ocaml-solo5` via `opam` into an `ubuntu-latest` GitHub machine. For the record, without this patch, I get an error (you can see [here](https://github.com/robur-coop/mkernel/actions/runs/17854920443/job/50771659811)) and with this patch, it seems that we are able to install correctly `ocaml-solo5` (you can see the output [here](https://github.com/robur-coop/mkernel/actions/runs/17856620250/job/50777038342) - the error in the CI is unrelated to `ocaml-solo5`).

I suspect the `set -x` but it's highly related to #151. @shym do you have any insights?