### PR TITLE
Add an `opatch` command and use it instead of `git apply`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,17 +90,23 @@ $(TOOLDIR_FINAL)/$(MAKECONF_TARGET_ARCH)-solo5-ocaml-%: \
 .PHONY: toolchains
 toolchains: $(TOOLCHAIN_FOR_BUILD) $(TOOLCHAIN_FINAL)
 
+# OPATCH
+opatch: opatch.ml
+	ocamlfind opt -package unix -package patch -linkpkg $< -o $@
+
 # OCAML
 # Extract sources from the ocaml-src package and apply patches if there any in
 # `patches/<OCaml version>/`
-ocaml:
+ocaml: | opatch
 # First make sure the ocaml directory doesn't exist, otherwise the cp would
 # create an ocaml-src subdirectory
 	test ! -d $@
 	cp -r "$$(ocamlfind query ocaml-src)" $@
 	VERSION="$$(head -n1 ocaml/VERSION)" ; \
 	if test -d "patches/$$VERSION" ; then \
-	  git apply --directory=$@ "patches/$$VERSION"/*; \
+	  for patch in "patches/$$VERSION"/*; do \
+	    (cd $@ && ../opatch) < "$$patch"; \
+	  done; \
 	fi
 
 ocaml/Makefile.config: $(LIBS) $(TOOLCHAIN_FOR_BUILD) | ocaml

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,7 @@ ocaml: | opatch
 	cp -r "$$(ocamlfind query ocaml-src)" $@
 	VERSION="$$(head -n1 ocaml/VERSION)" ; \
 	if test -d "patches/$$VERSION" ; then \
-	  for patch in "patches/$$VERSION"/*; do \
-	    (cd $@ && ../opatch) < "$$patch"; \
-	  done; \
+	  ./opatch -v -C $@ "patches/$$VERSION"/*; \
 	fi
 
 ocaml/Makefile.config: $(LIBS) $(TOOLCHAIN_FOR_BUILD) | ocaml

--- a/ocaml-solo5-cross-aarch64.opam
+++ b/ocaml-solo5-cross-aarch64.opam
@@ -32,6 +32,7 @@ depends: [
   "conf-pkg-config" {build} # to detect how to link with zstd
   "ocamlfind" {build} # needed by dune context (for tests)
   "ocaml-src" {build}
+  "patch" {build & >= "3.0.0"}
   "ocaml" {= "5.3.0"}
   "solo5" {>= "0.9.1"}
   "solo5-cross-aarch64" {>= "0.9.1" }

--- a/ocaml-solo5.opam
+++ b/ocaml-solo5.opam
@@ -32,6 +32,7 @@ depends: [
   "conf-pkg-config" {build} # to detect how to link with zstd
   "ocamlfind" {build} # needed by dune context (for tests)
   "ocaml-src" {build}
+  "patch" {build & >= "3.0.0"}
   "ocaml" {= "5.3.0"}
   "solo5" {>= "0.9.1"}
 ]

--- a/opatch.ml
+++ b/opatch.ml
@@ -82,9 +82,61 @@ let apply ~force ~dir diffs =
   in
   List.iter apply diffs
 
-let main ~dir patch =
+let apply ~dir ~strip patch =
   let content = In_channel.input_all patch in
-  let diffs = Patch.parse ~p:1 content in
+  let diffs = Patch.parse ~p:strip content in
   apply ~force:false ~dir diffs
 
-let _ = main ~dir:"." In_channel.stdin
+let parse_argv argv =
+  let open Arg in
+  let strip = ref 1
+  and dir = ref "."
+  and patches = ref []
+  and verbose = ref false in
+  let add_patch special = function
+    | "-" when special -> patches := None :: !patches
+    | x -> patches := Some x :: !patches
+  in
+  let specs =
+    [
+      ( "-p",
+        Arg.Set_int strip,
+        "<NUM>  Strip <NUM> directories from the diff paths (default: 1)" );
+      ( "-C",
+        Arg.Set_string dir,
+        "<DIR>  Locate files to patch as if launched in <DIR> instead of ." );
+      ( "-v",
+        Arg.Set verbose,
+        " Set verbose mode, where applied patches are logged" );
+      ( "--",
+        Arg.Rest (add_patch false),
+        " Process all remaining arguments as patches" );
+    ]
+  and usage = "opatch [-C <DIR>] [-p <NUM>] [PATCH...]: apply a diff file" in
+  try
+    parse_argv ~current:(ref 0) argv specs (add_patch true) usage;
+    let rec open_all chs = function
+      | [] -> chs
+      | Some p :: patches ->
+          open_all ((In_channel.open_bin p, p) :: chs) patches
+      | None :: patches -> open_all ((In_channel.stdin, "-") :: chs) patches
+    in
+    ( !strip,
+      !dir,
+      open_all [] (match !patches with [] -> [ None ] | p -> p),
+      !verbose )
+  with
+  | Help msg ->
+      Printf.printf "%s" msg;
+      exit 0
+  | Bad msg ->
+      Printf.eprintf "%s" msg;
+      exit 1
+
+let () =
+  let strip, dir, patches, verbose = parse_argv Sys.argv in
+  List.iter
+    (fun (patch, path) ->
+      apply ~dir ~strip patch;
+      if verbose then Printf.printf "%S applied.\n%!" path)
+    patches

--- a/opatch.ml
+++ b/opatch.ml
@@ -1,0 +1,90 @@
+(* This file is largely extracted from Opam's OpamSystem module, with a lot *)
+(* of shortcuts^W simplifications on the way                                *)
+(*                                                                          *)
+(* SPDX-License-Identifier: LGPL-2.1-only WITH OCaml-LGPL-linking-exception *)
+(* Copyright 2012-2020 OCamlPro                                             *)
+(* Copyright 2012 INRIA                                                     *)
+(* Copyright 2025 Tarides                                                   *)
+
+let realpath p =
+  let open Filename in
+  match try Some (Sys.is_directory p) with Sys_error _ -> None with
+  | None ->
+      let rec resolve dir =
+        if Sys.file_exists dir then Unix.realpath dir
+        else
+          let parent = dirname dir in
+          if dir = parent then dir else concat (resolve parent) (basename dir)
+      in
+      let p = if is_relative p then concat (Sys.getcwd ()) p else p in
+      resolve p
+  | Some true -> Unix.realpath p
+  | Some false -> (
+      let dir = Unix.realpath (dirname p) in
+      match basename p with "." -> dir | base -> concat dir base)
+
+let read path = In_channel.(with_open_bin path input_all)
+
+let write path content =
+  Out_channel.(with_open_bin path (fun oc -> output_string oc content))
+
+let apply ~force ~dir diffs =
+  (* NOTE: It is important to keep this `concat dir ""` to ensure the
+     is_prefix_of below doesn't match another similarly named directory *)
+  let dir = Filename.concat (realpath dir) "" in
+  let get_path file =
+    let file = realpath (Filename.concat dir file) in
+    if not (String.starts_with ~prefix:dir file) then
+      invalid_arg "Patch tried to escape its scope";
+    file
+  in
+  let patch content diff =
+    (* NOTE: The None case returned by [Patch.patch] is only returned
+       if [diff = Patch.Delete _]. This sub-function is not called in
+       this case so we [assert false] instead. *)
+    match Patch.patch ~cleanly:true content diff with
+    | Some x -> x
+    | None -> assert false (* See NOTE above *)
+    | exception _ when not force -> invalid_arg "Patch does not apply cleanly"
+    | exception _ -> (
+        match Patch.patch ~cleanly:false content diff with
+        | Some x -> x
+        | None -> assert false (* See NOTE above *)
+        | exception _ -> invalid_arg "Patch does not apply")
+  in
+  let apply diff =
+    match diff.Patch.operation with
+    | Patch.Edit (file1, file2) ->
+        let file1 = get_path file1 in
+        let file2 = get_path file2 in
+        let file1_exists = Sys.file_exists file1 in
+        (* That seems to be the GNU patch behaviour *)
+        let file = if file1_exists then file1 else file2 in
+        let content = read file in
+        let content = patch (Some content) diff in
+        write file2 content
+        (* FIXME: remove directory of file1 if now empty? *)
+    | Patch.Delete file | Patch.Git_ext (file, _, Patch.Delete_only) ->
+        let file = get_path file in
+        Unix.unlink file
+        (* FIXME: Windows *)
+        (* FIXME: remove directory of file if now empty? *)
+    | Patch.Create file | Patch.Git_ext (_, file, Patch.Create_only) ->
+        let file = get_path file in
+        let content = patch None diff in
+        write file content
+    | Patch.Git_ext (_, _, Patch.Rename_only (src, dst)) ->
+        let src = get_path src in
+        let dst = get_path dst in
+        (* FIXME: create directory of dst if needed *)
+        Unix.rename src dst
+        (* FIXME: remove directory of src if now empty? *)
+  in
+  List.iter apply diffs
+
+let main ~dir patch =
+  let content = In_channel.input_all patch in
+  let diffs = Patch.parse ~p:1 content in
+  apply ~force:false ~dir diffs
+
+let _ = main ~dir:"." In_channel.stdin

--- a/patches/5.3.0/0001-Use-target-instead-of-host-to-detect-the-C-toolchain.patch
+++ b/patches/5.3.0/0001-Use-target-instead-of-host-to-detect-the-C-toolchain.patch
@@ -35,57 +35,980 @@ Note that all these changes are transparent when `host` = `target`.
  2 files changed, 26 insertions(+)
 
 diff --git a/configure b/configure
-index 401b94298e4f34946677a409560ce1832c5bbbbc..e407887556f95b1a0cf36e89b4801af172231845 100755
-GIT binary patch
-delta 2466
-zcmZ`(eQXp(6wl2^uRV%@6xy^<h8_gcdX<V&tQ4(9LeN-6NiCx1_HM4-xVL-k?$Lrk
-zTTDPmT1`MF6cbBO6b#rXGC_?PL0ST+#3%~<VS>gW@)cr(2*KIA8H65fy2-ou`Fp?j
-z-n`W_^}`RQw(s__uC}_R)VB2~B@x?loN&a7Cv-zMn}}vci53aFmSuz!HjU}6WT|HB
-zTBAW7;^=0C61SO>TH<*`nl;@dx)TVJq(h@ZN1CWfZOs*4n%zWQ60t;)mS$>_#-wgU
-zQzb}bwpUfyysFd=3<6PYS^+&qT<W-_wPaE{Q&=-}%_$)ht4S-{x5qbTWGbOjd)l29
-z{z4qrmNim#Y(`c=P{iKm<An}Nmx{?<Mx8)RPye&4<NcEdQBZvwhLCXN8@hbkE8ALh
-z!yr-W(uhm6bcZ3=3N>2-`K=T+Cf&g#n53>&iyMNvRQET@AT5-b)FX2c&4S!iHz`A!
-zlQv=}O;?Xo;#eY1<Z@{|VcB9}#xj8`rkj*_U`oXhjii{M=8(AN6(ljsmNU9(6iM7>
-z&Gib1R0-QkP~mgSoCQcTrZ**R8Z9SJTJFo<GKc`LM711v(iEHGcwJ~Vy=CZ`ji$=!
-zj@TdK+M4MkM1bk0fr;LePEs?xy&@6Kq2;XNpl_g1?t<lHEC{Ra^NqtPJ73)As~Me^
-zS;vd;87Ut7*QfFNlfHFh?r3|IzjDcUJtxD)MckO;>~!fV<*cJKtC9x`!Hvh#u6*)K
-zpet9(dkj!JDkB9GDW>t&t3dI%T*;H*Kd!MQ?fxQm?{VN~N4i0=j62s2mavb0$<E<)
-zGe}^m)i#6Y*^VAS*s0B+i0ykD<nrZPz!e}fhQ&~IlO<jQW7+GKD35P@7pxwZ0fl$;
-zg2gDU=D+R+M`eEA`x%%4r2fnopetL-%fA5-6{S&^Jmf8h86c^dkn~ybjfcQQ+5aHA
-zr}5c8fzN$1)3xJ3AD)&o{LcRlW{n)e_Q?QvKQM&tv=2U@@)tokTFDg%_R0>}Z@I8t
-zLTDNePnAh|?t`#Qxw}<xyX1<Kxv)SI!Gt`MJM-Wf#YXsPIAN$B{9$N8iPN_o7IW4J
-zJBI?kGY;Pz%67OF)(vIb`YMdw!6v3!As!`oC!$ie1Djyg2-&#+*RMK1vIB0Cx5Ash
-zgn4rRd0QV`7?jOCQibx^*+1d^^7pm@xR|Xv3+Kz<D{4^#TYDA;S;HJOo=5+JIg$sS
-zxBz2{%<r$le17o~jLG$54Ff6#7b!~>cOs^qm0pEgC0r4AkGv^<V;D-5Wo|qd8^23!
-zuYmhwmV{PNgEX0DMGd;Hx)zA1kCpn58_-OpKeq_A6-vF8MC(<`Yc1%cT7eVos9POP
-z%Nq2sI;Oqr(J|%IxdC<GrRvtA>wr&r51p6q6YJfNN?F?vD4Wm!8bwrXq1F8|X53-4
-zMbYuqx9IV-nh9|dzwbL#MHI#hXqLjb>k>Mxa&5efUdRolk2buNno-OC|8|M^^WIc>
-zzpi*T#6`1FIjH2*S$MD7t}6j-$hx6CT*B84!&_8;Lh*;J#q!7Eza^Xz`8U=4p8}kt
-zpy49iakunY7s4U69ebzYg>q7SR3*-rm&MEG;ET$qcpk1%c^c>AsFDvofoDsZ1?uo~
-zBW1VZ8H^gya>rs57vLa^Ex?!gnx}B5f;;?KJb{Jl@d!R=0Y0b*6WV@N@#lJcK<VFU
-zz>9(s`Lz|eUk$sj16Qd5qc`yC>5?h&?&R~H{dlh0@iTq+yo^85k9(wg?aHHAd|Bf2
-Oi!Yn6JesrV(f<Gm^M=X*
-
-delta 1275
-zcmX|AdrZ_v5YBIB=k7SE$AP>d9N46$P!i&!L@2gCYSk87c~nIdJt1P$(;R<j+A0_t
-zA~6?(w5vp@nu-)FF_E~IL{qf^R5ZaqOi*Ktj~G<6i4ygaqurZ1{bQ4FznS^w+uhj{
-zUDJL&JgvUhQUN`8pLOh0RdLyRny|s=uUq5uJ8Nq^b=Cel&-Sbj4W+8CSZQE@Zn$E7
-z5vQt>?R)gnyH;O3L1kd9?s{c~qTcWGwD&)&H{BK%{3us7+_KHkCFw$ZNir+FA`nez
-z%qQl#!&S}te1k}*F6v&pSQw6~oDQ*#K<e+JLWep;GE$Y<wgI8O<KpxrHWWN9awL)2
-zXT>#644o6R1abL)i-3dB)j<I=F>EZWz*D!OdW+NJ@vik(d%{Q6qeCJynhhNo5q%bw
-ze1BWie!yM685M;w3=@LlxRc>xgqfV$XoEOLhwN~QI;!ttpq_MY#=xCyRqS-e>48E>
-z<-EtA!5@<-{L3OpBDcz*eEnnzj5^fj`!>72QwpgO1C8sz2daOM!=+^n{6+?vb>22;
-zjd)r1BP@-;+$N}rz|0otioo)AC~%R2G77P}_fP0%E8ZSB7)MsDi!ddMP|8&(n;On`
-ztKH9Gc9>Hao<k=EH@$$PpswvR!M!0^q$YxJOuJseM%LRo4nIlm6di=3ceShZi6C4T
-z@9UmXz$7Q?)(MDrlXQ<uZq25EdE-1?S|Hm5+0a&z9I&zK$b4Bw+0z%u5cO2X(h40|
-zC~w76U~{F+XEWWa<*pPe)3bNTojexjevr3$EZQ4o8xKukvz)_&R3DJT94%L}Z8Etb
-z{o+p9l0n;D1M*|F^^$bx#D3}JPKK+sQ}?m!@(2y8+J8eXA?m>mx!OZV*QGCIF574t
-zmk+qs_gYrc*HFWNY4rMF22`DomRUMg;$Kca`J>5L#fK?(p>{B7V1l|i1zqZ75@zUi
-zNvQZzCX#WSy1z-m$K2>)8b<Mjp2<LeEJe5H;V1mBx@TZn<c|A4$5@?JfN%N7dcMMc
-zBlDN}HO^%J6~(xo(Ldi}5g}zS!R4g7z65)iidl{sYK{+GdO<n%vk$`!M)XE2@GO&^
-zmAG;$6=MSq(g?Zry`M3M-axxsarblz9~i(&sXCm_B;^{y5#q*%@G!k!Q_C=#Wi!ie
-MmP5A;M;)B|Kf&?R{Qv*}
-
+index 401b94298e..e407887556 100755
+--- a/configure
++++ b/configure
+@@ -3693,6 +3693,26 @@ test -n "$target_alias" &&
+     NONENONEs,x,x, &&
+   program_prefix=${target_alias}-
+ 
++# Override cross_compiling and ac_tool_prefix variables since the C toolchain is
++# used to generate target code when building a cross compiler
++cross_compiling=no
++if test x"$target_alias" != x
++then :
++  if test x"$build_alias" = x
++then :
++  cross_compiling=maybe
++else $as_nop
++  if test x"$build_alias" != x"$target_alias"
++then :
++  cross_compiling=yes
++fi
++fi
++fi
++if test -n "$target_alias"
++then :
++  ac_tool_prefix=$target_alias-
++fi
++
+ # Ensure that AC_CONFIG_LINKS will either create symlinks which are compatible
+ # with native Windows (i.e. NTFS symlinks, not WSL or Cygwin-emulated ones) or
+ # use its fallback mechanisms. Native Windows versions of ocamlc/ocamlopt cannot
+@@ -4339,14 +4359,19 @@ esac
+   fi
+ fi
+ 
++# libtool will detect a build-to-host C toolchain but when building an OCaml
++# cross compiler we need the C toolchain to build the target runtime so we
++# temporarily define host* values as macros for target* values so that the
++# proper toolchain is configured. Note that host=target unless we are building a
++# cross compiler so this is transparent for the usual use case.
+ # libtool expects host_os=mingw for native Windows
+ # Also, it has been observed that, on some platforms (e.g. msvc) LT_INIT
+ # alters the CFLAGS variable, so we save its value before calling the macro
+ # and restore it after the call
+-old_host_os=$host_os
+-if test x"$host_os" = "xwindows"
++old_host_os=$target_os
++if test x"$target_os" = "xwindows"
+ then :
+-  host_os=mingw
++  target_os=mingw
+ fi
+ saved_CFLAGS="$CFLAGS"
+ 
+@@ -4551,8 +4576,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     CC=$ac_ct_CC
+@@ -4771,8 +4796,8 @@ done
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     CC=$ac_ct_CC
+@@ -4873,8 +4898,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     CC=$ac_ct_CC
+@@ -5108,7 +5133,7 @@ printf "%s\n" "$ac_try_echo"; } >&5
+ 	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+ printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+ as_fn_error 77 "cannot run C compiled programs.
+-If you meant to cross compile, use \`--host'.
++If you meant to cross compile, use \`--target'.
+ See \`config.log' for more details" "$LINENO" 5; }
+     fi
+   fi
+@@ -5776,7 +5801,7 @@ if test yes = "$GCC"; then
+   # Check if gcc -print-prog-name=ld gives a path.
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ld used by $CC" >&5
+ printf %s "checking for ld used by $CC... " >&6; }
+-  case $host in
++  case $target in
+   *-*-mingw*)
+     # gcc leaves a trailing carriage return, which upsets mingw
+     ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
+@@ -5888,7 +5913,7 @@ else $as_nop
+   lt_cv_path_NM=$NM
+ else
+   lt_nm_to_check=${ac_tool_prefix}nm
+-  if test -n "$ac_tool_prefix" && test "$build" = "$host"; then
++  if test -n "$ac_tool_prefix" && test "$build" = "$target"; then
+     lt_nm_to_check="$lt_nm_to_check nm"
+   fi
+   for lt_tmp_nm in $lt_nm_to_check; do
+@@ -6043,8 +6068,8 @@ done
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     DUMPBIN=$ac_ct_DUMPBIN
+@@ -6288,13 +6313,13 @@ esac
+ 
+ 
+ 
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to convert $build file names to $host format" >&5
+-printf %s "checking how to convert $build file names to $host format... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to convert $build file names to $target format" >&5
++printf %s "checking how to convert $build file names to $target format... " >&6; }
+ if test ${lt_cv_to_host_file_cmd+y}
+ then :
+   printf %s "(cached) " >&6
+ else $as_nop
+-  case $host in
++  case $target in
+   *-*-mingw* )
+     case $build in
+       *-*-mingw* ) # actually msys
+@@ -6344,7 +6369,7 @@ then :
+ else $as_nop
+   #assume ordinary cross tools, or native build.
+ lt_cv_to_tool_file_cmd=func_convert_file_noop
+-case $host in
++case $target in
+   *-*-mingw* )
+     case $build in
+       *-*-mingw* ) # actually msys
+@@ -6380,7 +6405,7 @@ case $reload_flag in
+ *) reload_flag=" $reload_flag" ;;
+ esac
+ reload_cmds='$LD$reload_flag -o $output$reload_objs'
+-case $host_os in
++case $target_os in
+   cygwin* | mingw* | pw32* | cegcc*)
+     if test yes != "$GCC"; then
+       reload_cmds=false
+@@ -6495,8 +6520,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     OBJDUMP=$ac_ct_OBJDUMP
+@@ -6535,7 +6560,7 @@ lt_cv_deplibs_check_method='unknown'
+ # If you have 'file' or equivalent on your system and you're not sure
+ # whether 'pass_all' will *always* work, you probably want this one.
+ 
+-case $host_os in
++case $target_os in
+ aix[4-9]*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+@@ -6582,7 +6607,7 @@ darwin* | rhapsody*)
+ 
+ freebsd* | dragonfly*)
+   if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
+-    case $host_cpu in
++    case $target_cpu in
+     i*86 )
+       # Not sure whether the presence of OpenBSD here was a mistake.
+       # Let's accept both of them until this is cleared up.
+@@ -6602,7 +6627,7 @@ haiku*)
+ 
+ hpux10.20* | hpux11*)
+   lt_cv_file_magic_cmd=/usr/bin/file
+-  case $host_cpu in
++  case $target_cpu in
+   ia64*)
+     lt_cv_deplibs_check_method='file_magic (s[0-9][0-9][0-9]|ELF-[0-9][0-9]) shared object file - IA64'
+     lt_cv_file_magic_test_file=/usr/lib/hpux32/libc.so
+@@ -6681,7 +6706,7 @@ sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
+   ;;
+ 
+ sysv4 | sysv4.3*)
+-  case $host_vendor in
++  case $target_vendor in
+   motorola)
+     lt_cv_deplibs_check_method='file_magic ELF [0-9][0-9]*-bit [ML]SB (shared object|dynamic lib) M[0-9][0-9]* Version [0-9]'
+     lt_cv_file_magic_test_file=`echo /usr/lib/libc.so*`
+@@ -6721,8 +6746,8 @@ printf "%s\n" "$lt_cv_deplibs_check_method" >&6; }
+ 
+ file_magic_glob=
+ want_nocaseglob=no
+-if test "$build" = "$host"; then
+-  case $host_os in
++if test "$build" = "$target"; then
++  case $target_os in
+   mingw* | pw32*)
+     if ( shopt | grep nocaseglob ) >/dev/null 2>&1; then
+       want_nocaseglob=yes
+@@ -6850,8 +6875,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     DLLTOOL=$ac_ct_DLLTOOL
+@@ -6879,7 +6904,7 @@ then :
+ else $as_nop
+   lt_cv_sharedlib_from_linklib_cmd='unknown'
+ 
+-case $host_os in
++case $target_os in
+ cygwin* | mingw* | pw32* | cegcc*)
+   # two different shell functions defined in ltmain.sh;
+   # decide which one to use based on capabilities of $DLLTOOL
+@@ -7013,8 +7038,8 @@ done
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     AR=$ac_ct_AR
+@@ -7186,8 +7211,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     STRIP=$ac_ct_STRIP
+@@ -7295,8 +7320,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     RANLIB=$ac_ct_RANLIB
+@@ -7318,7 +7343,7 @@ old_postinstall_cmds='chmod 644 $oldlib'
+ old_postuninstall_cmds=
+ 
+ if test -n "$RANLIB"; then
+-  case $host_os in
++  case $target_os in
+   bitrig* | openbsd*)
+     old_postinstall_cmds="$old_postinstall_cmds~\$RANLIB -t \$tool_oldlib"
+     ;;
+@@ -7329,7 +7354,7 @@ if test -n "$RANLIB"; then
+   old_archive_cmds="$old_archive_cmds~\$RANLIB \$tool_oldlib"
+ fi
+ 
+-case $host_os in
++case $target_os in
+   darwin*)
+     lock_old_archive_extraction=yes ;;
+   *)
+@@ -7449,7 +7474,7 @@ symcode='[BCDEGRST]'
+ sympat='\([_A-Za-z][_A-Za-z0-9]*\)'
+ 
+ # Define system-specific variables.
+-case $host_os in
++case $target_os in
+ aix*)
+   symcode='[BCDT]'
+   ;;
+@@ -7457,7 +7482,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+-  if test ia64 = "$host_cpu"; then
++  if test ia64 = "$target_cpu"; then
+     symcode='[ABCDEGRST]'
+   fi
+   ;;
+@@ -7872,7 +7897,7 @@ func_cc_basename ()
+         *) break;;
+       esac
+     done
+-    func_cc_basename_result=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++    func_cc_basename_result=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$target_alias-%%"`
+ }
+ 
+ # Check whether --enable-libtool-lock was given.
+@@ -7885,7 +7910,7 @@ test no = "$enable_libtool_lock" || enable_libtool_lock=yes
+ 
+ # Some flags need to be propagated to the compiler or linker for good
+ # libtool support.
+-case $host in
++case $target in
+ ia64-*-hpux*)
+   # Find out what ABI is being produced by ac_compile, and set mode
+   # options accordingly.
+@@ -7996,7 +8021,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   test $ac_status = 0; }; then
+     case `/usr/bin/file conftest.o` in
+       *32-bit*)
+-	case $host in
++	case $target in
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+@@ -8025,7 +8050,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	esac
+ 	;;
+       *64-bit*)
+-	case $host in
++	case $target in
+ 	  x86_64-*kfreebsd*-gnu)
+ 	    LD="${LD-ld} -m elf_x86_64_fbsd"
+ 	    ;;
+@@ -8113,7 +8138,7 @@ printf "%s\n" "$lt_cv_cc_needs_belf" >&6; }
+     *64-bit*)
+       case $lt_cv_prog_gnu_ld in
+       yes*)
+-        case $host in
++        case $target in
+         i?86-*-solaris*|x86_64-*-solaris*)
+           LD="${LD-ld} -m elf_x86_64"
+           ;;
+@@ -8233,8 +8258,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     MANIFEST_TOOL=$ac_ct_MANIFEST_TOOL
+@@ -8270,7 +8295,7 @@ fi
+ 
+ 
+ 
+-  case $host_os in
++  case $target_os in
+     rhapsody* | darwin*)
+     if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}dsymutil", so it can be a program name with args.
+@@ -8364,8 +8389,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     DSYMUTIL=$ac_ct_DSYMUTIL
+@@ -8466,8 +8491,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     NMEDIT=$ac_ct_NMEDIT
+@@ -8568,8 +8593,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     LIPO=$ac_ct_LIPO
+@@ -8670,8 +8695,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     OTOOL=$ac_ct_OTOOL
+@@ -8772,8 +8797,8 @@ fi
+   else
+     case $cross_compiling:$ac_tool_warned in
+ yes:)
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with target triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with target triplet" >&2;}
+ ac_tool_warned=yes ;;
+ esac
+     OTOOL64=$ac_ct_OTOOL64
+@@ -8915,7 +8940,7 @@ _LT_EOF
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_force_load" >&5
+ printf "%s\n" "$lt_cv_ld_force_load" >&6; }
+-    case $host_os in
++    case $target_os in
+     rhapsody* | darwin1.[012])
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+@@ -8924,7 +8949,7 @@ printf "%s\n" "$lt_cv_ld_force_load" >&6; }
+       # if running on 10.5 or later, the deployment target defaults
+       # to the OS version, if on x86, and 10.4, the deployment
+       # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
++      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$target in
+ 	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+ 	10.[012][,.]*)
+@@ -9163,7 +9188,7 @@ fi
+ 
+ 
+   shared_archive_member_spec=
+-case $host,$enable_shared in
++case $target,$enable_shared in
+ power*-*-aix[5-9]*,yes)
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking which variant of shared library versioning to provide" >&5
+ printf %s "checking which variant of shared library versioning to provide... " >&6; }
+@@ -9302,7 +9327,7 @@ printf "%s\n" "#define LT_OBJDIR \"$lt_cv_objdir/\"" >>confdefs.h
+ 
+ 
+ 
+-case $host_os in
++case $target_os in
+ aix3*)
+   # AIX sometimes has problems with the GCC collect2 program.  For some
+   # reason, if we set the COLLECT_NAMES environment variable, the problems
+@@ -9614,10 +9639,10 @@ lt_prog_compiler_static=
+     lt_prog_compiler_wl='-Wl,'
+     lt_prog_compiler_static='-static'
+ 
+-    case $host_os in
++    case $target_os in
+       aix*)
+       # All AIX code is PIC.
+-      if test ia64 = "$host_cpu"; then
++      if test ia64 = "$target_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	lt_prog_compiler_static='-Bstatic'
+       fi
+@@ -9625,7 +9650,7 @@ lt_prog_compiler_static=
+       ;;
+ 
+     amigaos*)
+-      case $host_cpu in
++      case $target_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+             lt_prog_compiler_pic='-fPIC'
+@@ -9649,7 +9674,7 @@ lt_prog_compiler_static=
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+       # (--disable-auto-import) libraries
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+-      case $host_os in
++      case $target_os in
+       os2*)
+ 	lt_prog_compiler_static='$wl-static'
+ 	;;
+@@ -9672,7 +9697,7 @@ lt_prog_compiler_static=
+       # PIC is the default for 64-bit PA HP-UX, but not for 32-bit
+       # PA HP-UX.  On IA64 HP-UX, PIC is the default but the pic flag
+       # sets the default TLS model and affects inlining.
+-      case $host_cpu in
++      case $target_cpu in
+       hppa*64*)
+ 	# +Z the default
+ 	;;
+@@ -9721,10 +9746,10 @@ lt_prog_compiler_static=
+     esac
+   else
+     # PORTME Check for flag to pass linker flags through the system compiler.
+-    case $host_os in
++    case $target_os in
+     aix*)
+       lt_prog_compiler_wl='-Wl,'
+-      if test ia64 = "$host_cpu"; then
++      if test ia64 = "$target_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	lt_prog_compiler_static='-Bstatic'
+       else
+@@ -9750,7 +9775,7 @@ lt_prog_compiler_static=
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
+-      case $host_os in
++      case $target_os in
+       os2*)
+ 	lt_prog_compiler_static='$wl-static'
+ 	;;
+@@ -9761,7 +9786,7 @@ lt_prog_compiler_static=
+       lt_prog_compiler_wl='-Wl,'
+       # PIC is the default for IA64 HP-UX and 64-bit HP-UX, but
+       # not for PA HP-UX.
+-      case $host_cpu in
++      case $target_cpu in
+       hppa*64*|ia64*)
+ 	# +Z the default
+ 	;;
+@@ -9937,7 +9962,7 @@ lt_prog_compiler_static=
+     esac
+   fi
+ 
+-case $host_os in
++case $target_os in
+   # For platforms that do not support PIC, -DPIC is meaningless:
+   *djgpp*)
+     lt_prog_compiler_pic=
+@@ -10252,7 +10277,7 @@ printf %s "checking whether the $compiler linker ($LD) supports shared libraries
+   # Exclude shared library initialization/finalization symbols.
+   extract_expsyms_cmds=
+ 
+-  case $host_os in
++  case $target_os in
+   cygwin* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+@@ -10279,7 +10304,7 @@ printf %s "checking whether the $compiler linker ($LD) supports shared libraries
+   # that we're better off using the native interface for both.
+   lt_use_gnu_ld_interface=no
+   if test yes = "$with_gnu_ld"; then
+-    case $host_os in
++    case $target_os in
+       aix*)
+ 	# The AIX port of GNU ld has always aspired to compatibility
+ 	# with the native linker.  However, as the warning in the GNU ld
+@@ -10327,10 +10352,10 @@ printf %s "checking whether the $compiler linker ($LD) supports shared libraries
+     esac
+ 
+     # See if GNU ld supports shared libraries.
+-    case $host_os in
++    case $target_os in
+     aix[3-9]*)
+       # On AIX/PPC, the GNU linker is very broken
+-      if test ia64 != "$host_cpu"; then
++      if test ia64 != "$target_cpu"; then
+ 	ld_shlibs=no
+ 	cat <<_LT_EOF 1>&2
+ 
+@@ -10346,7 +10371,7 @@ _LT_EOF
+       ;;
+ 
+     amigaos*)
+-      case $host_cpu in
++      case $target_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+             archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+@@ -10448,7 +10473,7 @@ _LT_EOF
+ 
+     gnu* | linux* | tpf* | k*bsd*-gnu | kopensolaris*-gnu)
+       tmp_diet=no
+-      if test linux-dietlibc = "$host_os"; then
++      if test linux-dietlibc = "$target_os"; then
+ 	case $cc_basename in
+ 	  diet\ *) tmp_diet=yes;;	# linux-dietlibc with static linking (!diet-dyn)
+ 	esac
+@@ -10458,7 +10483,7 @@ _LT_EOF
+       then
+ 	tmp_addflag=' $pic_flag'
+ 	tmp_sharedflag='-shared'
+-	case $cc_basename,$host_cpu in
++	case $cc_basename,$target_cpu in
+         pgcc*)				# Portland Group C compiler
+ 	  whole_archive_flag_spec='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag'
+@@ -10612,7 +10637,7 @@ _LT_EOF
+     fi
+   else
+     # PORTME fill in a description of your system's linker (not GNU ld)
+-    case $host_os in
++    case $target_os in
+     aix3*)
+       allow_undefined_flag=unsupported
+       always_export_symbols=yes
+@@ -10628,7 +10653,7 @@ _LT_EOF
+       ;;
+ 
+     aix[4-9]*)
+-      if test ia64 = "$host_cpu"; then
++      if test ia64 = "$target_cpu"; then
+ 	# On IA64, the linker does run time linking by default, so we don't
+ 	# have to do anything special.
+ 	aix_use_runtimelinking=no
+@@ -10665,7 +10690,7 @@ _LT_EOF
+ 	#            lib.a(lib.so.V) shared, rtl:no
+ 	# "svr4,*"   lib.so.V(shr.o) shared, rtl:yes, for executables
+ 	#            lib.a           static archive
+-	case $host_os in aix4.[23]|aix4.[23].*|aix[5-9]*)
++	case $target_os in aix4.[23]|aix4.[23].*|aix[5-9]*)
+ 	  for ld_flag in $LDFLAGS; do
+ 	  if (test x-brtl = "x$ld_flag" || test x-Wl,-brtl = "x$ld_flag"); then
+ 	    aix_use_runtimelinking=yes
+@@ -10708,7 +10733,7 @@ _LT_EOF
+       esac
+ 
+       if test yes = "$GCC"; then
+-	case $host_os in aix4.[012]|aix4.[012].*)
++	case $target_os in aix4.[012]|aix4.[012].*)
+ 	# We only want to do this on AIX 4.2 and lower, the check
+ 	# below for broken collect2 doesn't work under 4.3+
+ 	  collect2name=`$CC -print-prog-name=collect2`
+@@ -10740,7 +10765,7 @@ _LT_EOF
+ 	shared_flag_svr4='-shared $wl-G'
+       else
+ 	# not using gcc
+-	if test ia64 = "$host_cpu"; then
++	if test ia64 = "$target_cpu"; then
+ 	# VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
+ 	# chokes on -Wl,-G. The following line is correct:
+ 	  shared_flag='-G'
+@@ -10813,7 +10838,7 @@ fi
+         hardcode_libdir_flag_spec='$wl-blibpath:$libdir:'"$aix_libpath"
+         archive_expsym_cmds='$CC -o $output_objdir/$soname $libobjs $deplibs $wl'$no_entry_flag' $compiler_flags `if test -n "$allow_undefined_flag"; then func_echo_all "$wl$allow_undefined_flag"; else :; fi` $wl'$exp_sym_flag:\$export_symbols' '$shared_flag
+       else
+-	if test ia64 = "$host_cpu"; then
++	if test ia64 = "$target_cpu"; then
+ 	  hardcode_libdir_flag_spec='$wl-R $libdir:/usr/lib:/lib'
+ 	  allow_undefined_flag="-z nodefs"
+ 	  archive_expsym_cmds="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\$wl$no_entry_flag"' $compiler_flags $wl$allow_undefined_flag '"\$wl$exp_sym_flag:\$export_symbols"
+@@ -10897,7 +10922,7 @@ fi
+       ;;
+ 
+     amigaos*)
+-      case $host_cpu in
++      case $target_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+             archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+@@ -11082,7 +11107,7 @@ fi
+ 
+     hpux11*)
+       if test yes,no = "$GCC,$with_gnu_ld"; then
+-	case $host_cpu in
++	case $target_cpu in
+ 	hppa*64*)
+ 	  archive_cmds='$CC -shared $wl+h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+@@ -11094,7 +11119,7 @@ fi
+ 	  ;;
+ 	esac
+       else
+-	case $host_cpu in
++	case $target_cpu in
+ 	hppa*64*)
+ 	  archive_cmds='$CC -b $wl+h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+@@ -11150,7 +11175,7 @@ fi
+ 	hardcode_libdir_flag_spec='$wl+b $wl$libdir'
+ 	hardcode_libdir_separator=:
+ 
+-	case $host_cpu in
++	case $target_cpu in
+ 	hppa*64*|ia64*)
+ 	  hardcode_direct=no
+ 	  hardcode_shlibpath_var=no
+@@ -11175,8 +11200,8 @@ fi
+ 	# work, assume that -exports_file does not work either and
+ 	# implicitly export all symbols.
+ 	# This should be the same for all languages, so no per-tag cache variable.
+-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the $host_os linker accepts -exported_symbol" >&5
+-printf %s "checking whether the $host_os linker accepts -exported_symbol... " >&6; }
++	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the $target_os linker accepts -exported_symbol" >&5
++printf %s "checking whether the $target_os linker accepts -exported_symbol... " >&6; }
+ if test ${lt_cv_irix_exported_symbol+y}
+ then :
+   printf %s "(cached) " >&6
+@@ -11349,7 +11374,7 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       fi
+       hardcode_libdir_flag_spec='-R$libdir'
+       hardcode_shlibpath_var=no
+-      case $host_os in
++      case $target_os in
+       solaris2.[0-5] | solaris2.[0-5].*) ;;
+       *)
+ 	# The compiler driver will combine and reorder linker options,
+@@ -11367,7 +11392,7 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       ;;
+ 
+     sunos4*)
+-      if test sequent = "$host_vendor"; then
++      if test sequent = "$target_vendor"; then
+ 	# Use $CC to link under sequent, because it throws in some extra .o
+ 	# files that make .init and .fini sections work.
+ 	archive_cmds='$CC -G $wl-h $soname -o $lib $libobjs $deplibs $compiler_flags'
+@@ -11381,7 +11406,7 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       ;;
+ 
+     sysv4)
+-      case $host_vendor in
++      case $target_vendor in
+ 	sni)
+ 	  archive_cmds='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+ 	  hardcode_direct=yes # is this really true???
+@@ -11470,8 +11495,8 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       ;;
+     esac
+ 
+-    if test sni = "$host_vendor"; then
+-      case $host in
++    if test sni = "$target_vendor"; then
++      case $target in
+       sysv4 | sysv4.2uw2* | sysv4.3* | sysv5*)
+ 	export_dynamic_flag_spec='$wl-Blargedynsym'
+ 	;;
+@@ -11724,11 +11749,11 @@ esac
+ printf %s "checking dynamic linker characteristics... " >&6; }
+ 
+ if test yes = "$GCC"; then
+-  case $host_os in
++  case $target_os in
+     darwin*) lt_awk_arg='/^libraries:/,/LR/' ;;
+     *) lt_awk_arg='/^libraries:/' ;;
+   esac
+-  case $host_os in
++  case $target_os in
+     mingw* | cegcc*) lt_sed_strip_eq='s|=\([A-Za-z]:\)|\1|g' ;;
+     *) lt_sed_strip_eq='s|=/|/|g' ;;
+   esac
+@@ -11786,7 +11811,7 @@ BEGIN {RS = " "; FS = "/|\n";} {
+ }'`
+   # AWK program above erroneously prepends '/' to C:/dos/paths
+   # for these hosts.
+-  case $host_os in
++  case $target_os in
+     mingw* | cegcc*) lt_search_path_spec=`$ECHO "$lt_search_path_spec" |\
+       $SED 's|/\([A-Za-z]:\)|\1|g'` ;;
+   esac
+@@ -11805,7 +11830,7 @@ finish_eval=
+ shlibpath_var=
+ shlibpath_overrides_runpath=unknown
+ version_type=none
+-dynamic_linker="$host_os ld.so"
++dynamic_linker="$target_os ld.so"
+ sys_lib_dlsearch_path_spec="/lib /usr/lib"
+ need_lib_prefix=unknown
+ hardcode_into_libs=no
+@@ -11816,7 +11841,7 @@ need_version=unknown
+ 
+ 
+ 
+-case $host_os in
++case $target_os in
+ aix3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   library_names_spec='$libname$release$shared_ext$versuffix $libname.a'
+@@ -11831,7 +11856,7 @@ aix[4-9]*)
+   need_lib_prefix=no
+   need_version=no
+   hardcode_into_libs=yes
+-  if test ia64 = "$host_cpu"; then
++  if test ia64 = "$target_cpu"; then
+     # AIX 5 supports IA64
+     library_names_spec='$libname$release$shared_ext$major $libname$release$shared_ext$versuffix $libname$shared_ext'
+     shlibpath_var=LD_LIBRARY_PATH
+@@ -11841,7 +11866,7 @@ aix[4-9]*)
+     # the line '#! .'.  This would cause the generated library to
+     # depend on '.', always an invalid library.  This was fixed in
+     # development snapshots of GCC prior to 3.0.
+-    case $host_os in
++    case $target_os in
+       aix4 | aix4.[01] | aix4.[01].*)
+       if { echo '#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 97)'
+ 	   echo ' yes '
+@@ -11921,7 +11946,7 @@ aix[4-9]*)
+   ;;
+ 
+ amigaos*)
+-  case $host_cpu in
++  case $target_cpu in
+   powerpc)
+     # Since July 2007 AmigaOS4 officially supports .so libraries.
+     # When compiling the executable, add -use-dynld -Lsobjs: to the compileline.
+@@ -11937,7 +11962,7 @@ amigaos*)
+ 
+ beos*)
+   library_names_spec='$libname$shared_ext'
+-  dynamic_linker="$host_os ld.so"
++  dynamic_linker="$target_os ld.so"
+   shlibpath_var=LIBRARY_PATH
+   ;;
+ 
+@@ -11980,7 +12005,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+        $RM \$dlpath'
+     shlibpath_overrides_runpath=yes
+ 
+-    case $host_os in
++    case $target_os in
+     cygwin*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+       soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+@@ -12066,7 +12091,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+   ;;
+ 
+ darwin* | rhapsody*)
+-  dynamic_linker="$host_os dyld"
++  dynamic_linker="$target_os dyld"
+   version_type=darwin
+   need_lib_prefix=no
+   need_version=no
+@@ -12095,7 +12120,7 @@ freebsd* | dragonfly*)
+   if test -x /usr/bin/objformat; then
+     objformat=`/usr/bin/objformat`
+   else
+-    case $host_os in
++    case $target_os in
+     freebsd[23].*) objformat=aout ;;
+     *) objformat=elf ;;
+     esac
+@@ -12114,7 +12139,7 @@ freebsd* | dragonfly*)
+       ;;
+   esac
+   shlibpath_var=LD_LIBRARY_PATH
+-  case $host_os in
++  case $target_os in
+   freebsd2.*)
+     shlibpath_overrides_runpath=yes
+     ;;
+@@ -12138,7 +12163,7 @@ haiku*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  dynamic_linker="$host_os runtime_loader"
++  dynamic_linker="$target_os runtime_loader"
+   library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LIBRARY_PATH
+@@ -12153,11 +12178,11 @@ hpux9* | hpux10* | hpux11*)
+   version_type=sunos
+   need_lib_prefix=no
+   need_version=no
+-  case $host_cpu in
++  case $target_cpu in
+   ia64*)
+     shrext_cmds='.so'
+     hardcode_into_libs=yes
+-    dynamic_linker="$host_os dld.so"
++    dynamic_linker="$target_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+     library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+@@ -12173,7 +12198,7 @@ hpux9* | hpux10* | hpux11*)
+   hppa*64*)
+     shrext_cmds='.sl'
+     hardcode_into_libs=yes
+-    dynamic_linker="$host_os dld.sl"
++    dynamic_linker="$target_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+     library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+@@ -12183,7 +12208,7 @@ hpux9* | hpux10* | hpux11*)
+     ;;
+   *)
+     shrext_cmds='.sl'
+-    dynamic_linker="$host_os dld.sl"
++    dynamic_linker="$target_os dld.sl"
+     shlibpath_var=SHLIB_PATH
+     shlibpath_overrides_runpath=no # +s is required to enable SHLIB_PATH
+     library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+@@ -12209,7 +12234,7 @@ interix[3-9]*)
+   ;;
+ 
+ irix5* | irix6* | nonstopux*)
+-  case $host_os in
++  case $target_os in
+     nonstopux*) version_type=nonstopux ;;
+     *)
+ 	if test yes = "$lt_cv_prog_gnu_ld"; then
+@@ -12222,7 +12247,7 @@ irix5* | irix6* | nonstopux*)
+   need_version=no
+   soname_spec='$libname$release$shared_ext$major'
+   library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$release$shared_ext $libname$shared_ext'
+-  case $host_os in
++  case $target_os in
+   irix5* | nonstopux*)
+     libsuff= shlibsuff=
+     ;;
+@@ -12482,7 +12507,7 @@ sysv4 | sysv4.3*)
+   library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+-  case $host_vendor in
++  case $target_vendor in
+     sni)
+       shlibpath_overrides_runpath=no
+       need_lib_prefix=no
+@@ -12522,7 +12547,7 @@ sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+     sys_lib_search_path_spec='/usr/ccs/lib /usr/lib'
+-    case $host_os in
++    case $target_os in
+       sco3.2v5*)
+         sys_lib_search_path_spec="$sys_lib_search_path_spec /lib"
+ 	;;
+@@ -12726,7 +12751,7 @@ else
+   lt_cv_dlopen=no
+   lt_cv_dlopen_libs=
+ 
+-  case $host_os in
++  case $target_os in
+   beos*)
+     lt_cv_dlopen=load_add_on
+     lt_cv_dlopen_libs=
+@@ -13261,7 +13286,7 @@ if test -n "$STRIP" && $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
+ printf "%s\n" "yes" >&6; }
+ else
+ # FIXME - insert some real tests, host_os isn't really good enough
+-  case $host_os in
++  case $target_os in
+   darwin*)
+     if test -n "$STRIP"; then
+       striplib="$STRIP -x"
+@@ -13303,7 +13328,7 @@ printf %s "checking whether to build shared libraries... " >&6; }
+ 
+   # On AIX, shared libraries and static libraries use the same namespace, and
+   # are all built from PIC.
+-  case $host_os in
++  case $target_os in
+   aix3*)
+     test yes = "$enable_shared" && enable_static=no
+     if test -n "$RANLIB"; then
+@@ -13313,7 +13338,7 @@ printf %s "checking whether to build shared libraries... " >&6; }
+     ;;
+ 
+   aix[4-9]*)
+-    if test ia64 != "$host_cpu"; then
++    if test ia64 != "$target_cpu"; then
+       case $enable_shared,$with_aix_soname,$aix_use_runtimelinking in
+       yes,aix,yes) ;;			# shared object as lib.so file only
+       yes,svr4,*) ;;			# shared object as lib.so archive member only
+@@ -13367,7 +13392,7 @@ CC=$lt_save_CC
+ 
+ 
+ CFLAGS="$saved_CFLAGS"
+-host_os=$old_host_os
++target_os=$old_host_os
+ 
+ case $host in #(
+   sparc-sun-solaris*) :
 diff --git a/configure.ac b/configure.ac
 index 64e6d7e160..18b0681d26 100644
 --- a/configure.ac

--- a/patches/5.3.0/0002-Use-target-instead-of-host-when-relevant-in-configur.patch
+++ b/patches/5.3.0/0002-Use-target-instead-of-host-when-relevant-in-configur.patch
@@ -53,53 +53,901 @@ index 7353e09a96..242a0e6638 100644
    cross_compiling="$old_cross_compiling"
  ])
 diff --git a/configure b/configure
-index e407887556f95b1a0cf36e89b4801af172231845..9ef0edf50277e5cfc17ad978deef969df774805a 100755
-GIT binary patch
-delta 1759
-zcmaJ>YfMyE5YBy_b9M`RmjxDt02h|$x=R}fAP~?*TWhM77=odo+htjB+jX(*8mmRc
-zv<Yd{)?nh$2Nvriq@;;Wn;dPCK>DC<5C!|I(o}2!AGOfhRD;#_+<SM6@S{IYGIze2
-zIdkUw=JxgG-n)_8{ux)$3D3BYOjmYtQJiYp;Nh5LpgWIplesW2qYkL)=iZbvJ*_Rl
-zpv%*;eTUEQZG}M~%fNhrBQQ0@*`h=4)@E<W<@WpBK_{FTmnxRH27lpu=!yZZpIZXF
-z{iAdYx(2!1P|?mCm#<%wp=4((4Xs}H%f`l*fY<12QbOKfNOA5_GBO!lu7tLE14c!G
-z^CNtgNm1M$mnY;}zovqrP*umrX?;=FSC<Iyy-$oAA`ux%TiZf-Mw8ng^kx`YDMeA!
-zBVo+pWk|#yiBps&pRvgYuN*?l;Mxy7fgQ7aJdEDtWXdLS(a1OXIwpoWc6fFKc0@Wc
-zEQyKwi0}L?ZRI3wQuO&r>6TTuq5QtIcEQY|AKjN8h2x-aUV1H@lJ`J5gW=P?I1PHb
-zxOn(eK=I%ZQAw6kUar`3S-bW;rA+JEAE?Oj2NY+pDTjeZZ_w?5i#)nQbe@bxSmi<q
-z@P&X%K@?FgOo_+>`$bd;UlJ4xS432#HXTC~Bs7kpyb{awuP7u6^ne+?5T#*idKxvP
-zptUCLfv{ycnqENQ@Bp^JDLaaR{>{ij&p6OJO<~ED<fAyvlxg0R=&TLymSPLNxe5Ig
-zna_9CXgp#cuR$O3+6{C=Ejnq}uAu+Cj><Oc=CfB(fCFnWw$kq>(2HVtV9rUjii10X
-zWPpt>L}=S}bVREY1I)C8V;ZHv@O9Q-a0<2SjWZyMnx>Hyx!gK~N^rPf)o&;|T5sf~
-z2WWq+b;(i~RbeV+Ff_`i%ZoO`-w5fqxT3|<r|mM{%`f&H{XIAF7;vxBcPyCgBVR8h
-z!eA_p)wB*{v5frSxRget<8X}t(TyY#MgszZOIA!ob#tKKic^rTY}$~33pkirhSQS%
-z6ZD#Oo1R`>t*%R0*B~U}LI@sWdWeX6H7%9#LsidEl!Wub&vz%`b4Y)Fb~=6|F6{oe
-z2xk!824)|mTPkt4S!c$u5wDQ66gW2~CBdG0Y@-LOaekhL!|hunlm5CF_oeFJs-nPr
-zg1z#5H+E2SH!cn{rXiOK5r&a{OqPc}z%`nJVssU<oYVNR8V|m~$@Eb#PK;UVbbXHR
-z37V672k=VGw1F0XZ3xecDrBSVyMohX4?TrQgbQrh=+<xXjKQE2tM~$tT8mPsZybMB
-z{C`SVOfc*<kd=#Fbi_bBA{3a2L#MgkMACJd-!+kw0?3Ud2C7N~5&o8mS*LkUCaDpc
-z%PgdlgYh_$E~+%c@mP`scjHLGQdZgBy-zS!X=Xg>wCI!hI)@a5nViodm9p+-#8_x;
-z38@P$9zu$`)h0UEM-G@(#0t?j*lHc_CmZwip|Z@=0u0Iol{W13`5PUX+gjM)+ZPD`
-zqMSQCPS5V<UA}<B?zB6%`vT3o3JdIQ_QwGDWQbLMYL+|)`)0|>g_fY>DoTc`KS(N^
-dog)gob&ACu*@H!BpCic~m*)t*JZGr0{R^cvTsQy#
-
-delta 1111
-zcmYjPT})h65YA<}Gk5R)+-0L!7Hw{KX<3n75)4pCN_nHEiEC18(_catkWFxRVV4%8
-zNo`_E@Mjw!={)%J&<AYVn9$lXwl=73nrf6%X<}cfjSm%FtUuI5Q=;{pb18a~lYBGt
-zotbau%%49-Po0Rqc2=t&bM<C&+%%?@YxL*{Skyd^LC%hA#VCD$Q5&KB11(Hn&FdCV
-zUDamH;UjaJxFzDc#4Y6`bGmDdN>V85y_!PHi+ZtKA}W?Z`$Mpvce~&p#h`sUyrQVz
-z=`exxlpns)1wU_+e*_w+#e$HhFTJTcnYClto@z>15Th9%G|_+s2^H!~+p(MoO<S;4
-zN-yKb18^P5_Pc$&{1}wFXxBw;m>+~-msb+vJW>tqeoBpMKDyliKS*aAHSdQA*EGR1
-zD+3rB6%Bi$Vie~#!d)fugJ!r8QK)Ax6rCQocfg#3YCGY0iHhDx!iP1Emhl2?+##XG
-z^LHTaFcS;VU#gf_7NJemE2HzjLX_L?LQjc$DeZ5a9LIkHOEctH!geZ6hg+b6p122V
-z_~+k2LzQRgFYx(LQY52w32X`>2FYWhpH3oriT;3q<1@S%P(B_5Tn@^geU5vp@Nbi_
-z6@4^Vhn4CRYU$bm3{k^92=M21_!g`dIO@hq?r+4*BeFVqx8a+d-HPOh5oWZ^k>1{g
-zjXFI)uUFH@{TSgdQy70zhAQZ7k2}P*<9KSVwBxk%rjUB{ve0(_494i(6t1UdKf)Jy
-z<_vzKW>m-L&*Do8{-6HdFKF<qQ+NoSM1@(bq|j$rPLrKr((Ejjk5AsV=>1DB4<DPx
-zF9M3kf)^~6(BjiKaI;H6x%V-S-^BYXAz>#pwM=AAV+Bv%!UeaQ`MV2vr_q@n)EFl`
-ze7eCH4a&8$XxkQ}UXk9|VzgQ^vufDj#T~}({A#*&^l1h7`Sq`j!vV)Ru_WX~ZW)QV
-zdc<N%@3_d`44y-S>C{k1W}xF>D*beQ*xqD^hgRSo(_TFrHrV-Yu?FEPxeXl$y3<{m
-zftX`ta$$R&cvrQ5FxA(!8gncWH1oaPX}d*aOLpeEZHFcn%8o=$+iTavvdLKT<rhU&
-Y%31F1bj5N{{MXxXA>igh!2BulFHiD)hyVZp
-
+index e407887556..9ef0edf502 100755
+--- a/configure
++++ b/configure
+@@ -3727,7 +3727,7 @@ esac
+ 
+ # Systems that are known not to work, even in bytecode only.
+ 
+-case $host in #(
++case $target in #(
+   i386-*-solaris*) :
+     as_fn_error $? "Building for 32 bits target is not supported. \
+ If your host is 64 bits, you can try with './configure CC=\"gcc -m64\"' \
+@@ -3738,7 +3738,7 @@ esac
+ 
+ # MSVC special case
+ 
+-case $host in #(
++case $target in #(
+   *-pc-windows) :
+     if test -z "$CC"
+ then :
+@@ -4246,10 +4246,125 @@ else $as_nop
+ 
+ fi
+ 
++# Are we building a cross-compiler
++
++if test x"$host" = x"$target"
++then :
++  cross_compiler=false
++else $as_nop
++  cross_compiler=true
++fi
++
+ # Initialization of libtool
+ # Allow the MSVC linker to be found even if ld isn't installed.
+ # User-specified LD still takes precedence.
+-if test -n "$ac_tool_prefix"; then
++if $cross_compiler
++then :
++  for ac_prog in ld link
++do
++  # Extract the first word of "$target_alias-$ac_prog", so it can be a program name with args.
++set dummy $target_alias-$ac_prog; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_LD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$LD"; then
++  ac_cv_prog_LD="$LD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_LD="$target_alias-$ac_prog"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++LD=$ac_cv_prog_LD
++if test -n "$LD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
++printf "%s\n" "$LD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++  test -n "$LD" && break
++done
++if test -z "$LD"; then
++  if test "$build" = "$target"; then
++    ac_ct_LD=$LD
++    for ac_prog in ld link
++do
++  # Extract the first word of "$ac_prog", so it can be a program name with args.
++set dummy $ac_prog; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_LD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$ac_ct_LD"; then
++  ac_cv_prog_ac_ct_LD="$ac_ct_LD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_LD="$ac_prog"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++ac_ct_LD=$ac_cv_prog_ac_ct_LD
++if test -n "$ac_ct_LD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_LD" >&5
++printf "%s\n" "$ac_ct_LD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++  test -n "$ac_ct_LD" && break
++done
++test -n "$ac_ct_LD" || ac_ct_LD="false"
++
++    LD=$ac_ct_LD
++  else
++    LD="false"
++  fi
++fi
++
++else $as_nop
++  if test -n "$ac_tool_prefix"; then
+   for ac_prog in ld link
+   do
+     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+@@ -4359,6 +4474,7 @@ esac
+   fi
+ fi
+ 
++fi
+ # libtool will detect a build-to-host C toolchain but when building an OCaml
+ # cross compiler we need the C toolchain to build the target runtime so we
+ # temporarily define host* values as macros for target* values so that the
+@@ -13536,7 +13652,7 @@ else $as_nop
+ fi ;;
+ esac
+ 
+-case $host in #(
++case $target in #(
+   # In config/Makefile.mingw*, we had:
+   # TARGET=i686-w64-mingw32 and x86_64-w64-mingw32
+   # TOOLPREF=$(TARGET)-
+@@ -13548,7 +13664,7 @@ case $host in #(
+       mkexe_via_cc_extra_cmd=' && $(call MERGEMANIFESTEXE,$(1))'
+       libext=lib
+       AR=""
+-      if test "$host_cpu" = "x86_64"
++      if test "$target_cpu" = "x86_64"
+ then :
+   machine="-machine:AMD64 "
+ else $as_nop
+@@ -13759,8 +13875,8 @@ printf "%s\n" "$ocaml_cc_vendor" >&6; }
+ ## In cross-compilation mode, can we run executables produced?
+ # At the moment, it's required, but the fact is used in C99 function detection
+ 
+-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether host executables can be run in the build" >&5
+-printf %s "checking whether host executables can be run in the build... " >&6; }
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether target executables can be run in the build" >&5
++printf %s "checking whether target executables can be run in the build... " >&6; }
+   old_cross_compiling="$cross_compiling"
+   cross_compiling='no'
+   if test "$cross_compiling" = yes
+@@ -13784,11 +13900,11 @@ if ac_fn_c_try_run "$LINENO"
+ then :
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ printf "%s\n" "yes" >&6; }
+-    host_runnable=true
++    target_runnable=true
+ else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ printf "%s\n" "no" >&6; }
+-    host_runnable=false
++    target_runnable=false
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+   conftest.$ac_objext conftest.beam conftest.$ac_ext
+@@ -13838,6 +13954,14 @@ esac
+ ocamlsrcdir=$(unset CDPATH; cd -- "$srcdir" && printf %sX "$PWD") || fail
+ ocamlsrcdir=${ocamlsrcdir%X}
+ 
++case $host in #(
++  *-*-mingw32*|*-pc-windows) :
++    ln='cp -pf'
++    ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")" ;; #(
++  *) :
++    ln='ln -sf' ;;
++esac
++
+ # Whether ar supports @FILE arguments
+ 
+ case $lt_cv_ar_at_file in #(
+@@ -13847,23 +13971,20 @@ case $lt_cv_ar_at_file in #(
+     ar_supports_response_files=true ;;
+ esac
+ 
+-# Libraries to build depending on the host
++# Libraries to build depending on the target
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+     unix_or_win32="win32"
+-    ln='cp -pf'
+     ocamltest_libunix="Some false"
+-    ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
+     ocamlyacc_wstr_module="yacc/wstr" ;; #(
+   *) :
+     unix_or_win32="unix"
+-  ln='ln -sf'
+   ocamltest_libunix="Some true"
+   ocamlyacc_wstr_module="" ;;
+ esac
+ 
+-case $host in #(
++case $target in #(
+   *-*-cygwin*|*-*-mingw32*|*-pc-windows) :
+     exeext=".exe" ;; #(
+   *) :
+@@ -13935,7 +14056,7 @@ shebangscripts=false
+ launch_method='exe'
+ if test "x$interpval" = "xyes"
+ then :
+-  case $host in #(
++  case $target in #(
+   *-cygwin) :
+     # Cygwin supports shebangs, which we use for the compiler itself, but
+       # partially for legacy, and partially so that executables can be easily
+@@ -13963,15 +14084,6 @@ fi
+ ac_config_commands="$ac_config_commands shebang"
+ 
+ 
+-# Are we building a cross-compiler
+-
+-if test x"$host" = x"$target"
+-then :
+-  cross_compiler=false
+-else $as_nop
+-  cross_compiler=true
+-fi
+-
+ # Checks for programs
+ 
+ ## Check for the C compiler: done by libtool
+@@ -14100,7 +14212,7 @@ case $enable_warn_error,false in #(
+      ;;
+ esac
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+     case $WINDOWS_UNICODE_MODE in #(
+   ansi) :
+@@ -14204,7 +14316,7 @@ fi
+ esac
+ 
+ # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
+-case $host in #(
++case $target in #(
+   i686-*-mingw32*) :
+     internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
+   *) :
+@@ -14214,7 +14326,7 @@ esac
+ # Use 64-bit file offset if possible
+ # See also AC_SYS_LARGEFILE
+ # Problem: flags are added to CC rather than CPPFLAGS
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+      ;; #(
+   *) :
+@@ -14232,7 +14344,7 @@ esac
+ if test x"$enable_shared" = "xno"
+ then :
+   supports_shared_libraries=false
+-  case $host in #(
++  case $target in #(
+   *-pc-windows|*-w64-mingw32*) :
+     as_fn_error $? "Cannot build native Win32 with --disable-shared" "$LINENO" 5 ;; #(
+   *) :
+@@ -14244,7 +14356,7 @@ fi
+ 
+ # Define flexlink chain and flags correctly for the different Windows ports
+ flexlink_flags=''
+-case $host in #(
++case $target in #(
+   i686-*-cygwin) :
+     flexdll_chain='cygwin'
+     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
+@@ -14588,7 +14700,7 @@ fi
+ 
+ fi
+ 
+-case $have_flexdll_h,$supports_shared_libraries,$host in #(
++case $have_flexdll_h,$supports_shared_libraries,$target in #(
+   no,true,*-*-cygwin*) :
+     supports_shared_libraries=false
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
+@@ -14599,7 +14711,7 @@ printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disa
+      ;;
+ esac
+ 
+-case $flexdll_source_dir,$supports_shared_libraries,$flexlink,$host in #(
++case $flexdll_source_dir,$supports_shared_libraries,$flexlink,$target in #(
+   ,true,,*-*-cygwin*) :
+     supports_shared_libraries=false
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexlink not found: shared library support disabled." >&5
+@@ -14612,7 +14724,7 @@ esac
+ 
+ mkexe_cmd_exp="$CC"
+ 
+-case $ocaml_cc_vendor,$host in #(
++case $ocaml_cc_vendor,$target in #(
+   *,x86_64-*-darwin*) :
+     oc_ldflags='-Wl,-no_compact_unwind';
+     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
+@@ -14634,7 +14746,7 @@ else $as_nop
+ fi
+     ostype="Cygwin" ;; #(
+   *,*-*-mingw32*) :
+-    case $host in #(
++    case $target in #(
+   i686-*-*) :
+     oc_dll_ldflags="-static-libgcc" ;; #(
+   *) :
+@@ -14999,7 +15111,7 @@ then :
+ fi
+ 
+ 
+-case $host in #(
++case $target in #(
+   *-*-linux*) :
+     ac_fn_c_check_header_compile "$LINENO" "linux/futex.h" "ac_cv_header_linux_futex_h" "$ac_includes_default"
+ if test "x$ac_cv_header_linux_futex_h" = xyes
+@@ -15858,7 +15970,7 @@ fi
+ # Full support for thread local storage
+ # macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
+ 
+-case $host in #(
++case $target in #(
+   *-apple-darwin*|*-mingw32*|*-pc-windows) :
+      ;; #(
+   *) :
+@@ -15879,7 +15991,7 @@ natdynlinkopts=""
+ if test x"$enable_shared" != "xno"
+ then :
+   mkdll=''
+-  case $host in #(
++  case $target in #(
+   x86_64-apple-darwin*) :
+     mkdll_flags=\
+ '-shared -undefined dynamic_lookup -Wl,-no_compact_unwind -Wl,-w'
+@@ -15910,7 +16022,7 @@ esac ;; #(
+   *-*-linux*|*-*-freebsd[3-9]*|*-*-freebsd[1-9][0-9]*\
+     |*-*-openbsd*|*-*-netbsd*|*-*-dragonfly*|*-*-gnu*|*-*-haiku*) :
+     sharedlib_cflags="-fPIC"
+-       case $ocaml_cc_vendor,$host in #(
++       case $ocaml_cc_vendor,$target in #(
+   gcc-*,powerpc-*-linux*) :
+     mkdll_flags='-shared -mbss-plt' ;; #(
+   *,i[3456]86-*) :
+@@ -15920,7 +16032,7 @@ esac ;; #(
+   *) :
+     mkdll_flags='-shared' ;;
+ esac
+-       case $host in #(
++       case $target in #(
+   *-*-openbsd7.[3-9]|*-*-openbsd[89].*) :
+     mkdll_flags="${mkdll_flags} -Wl,--no-execute-only" ;; #(
+   *) :
+@@ -15950,7 +16062,7 @@ fi
+ # Make sure code sections in OCaml-generated executables are readable
+ # (required for marshaling of function closures)
+ 
+-case $host in #(
++case $target in #(
+   *-*-openbsd7.[3-9]|*-*-openbsd[89].*) :
+     oc_ldflags="$oc_ldflags -Wl,--no-execute-only"
+      natdynlinkopts="$natdynlinkopts -Wl,--no-execute-only" ;; #(
+@@ -15960,7 +16072,7 @@ esac
+ 
+ # Disable control flow integrity
+ 
+-case $host in #(
++case $target in #(
+   *-*-openbsd7.[4-9]|*-*-openbsd[89].*) :
+     oc_ldflags="$oc_ldflags -Wl,-z,nobtcfi"
+      natdynlinkopts="$natdynlinkopts -Wl,-z,nobtcfi" ;; #(
+@@ -15975,7 +16087,7 @@ natdynlink=false
+ 
+ if test x"$supports_shared_libraries" = 'xtrue'
+ then :
+-  case "$host" in #(
++  case "$target" in #(
+   *-*-cygwin*) :
+     natdynlink=true ;; #(
+   *-*-mingw32*) :
+@@ -16053,7 +16165,7 @@ case $enable_native_toplevel,$natdynlink in #(
+ esac
+ 
+ # Try to work around the Skylake/Kaby Lake processor bug.
+-case "$ocaml_cc_vendor,$host" in #(
++case "$ocaml_cc_vendor,$target" in #(
+   *gcc*,x86_64-*|*gcc*,i686-*) :
+     as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-fno-tree-vrp" | $as_tr_sh`
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -fno-tree-vrp" >&5
+@@ -16183,7 +16295,7 @@ system=unknown
+ # preserving $arch = 'none' <=> $system = 'unknown'
+ has_native_backend=no
+ native_ldflags=""
+-case $host in #(
++case $target in #(
+   i[3456]86-*-linux*) :
+     arch=i386; system=linux ;; #(
+   i[3456]86-*-freebsd*) :
+@@ -16350,7 +16462,105 @@ fi
+ printf "%s\n" "#define OCAML_OS_TYPE \"$ostype\"" >>confdefs.h
+ 
+ 
+-if test -n "$ac_tool_prefix"; then
++if $cross_compiler
++then :
++  # Extract the first word of "$target_alias-ld", so it can be a program name with args.
++set dummy $target_alias-ld; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_DIRECT_LD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$DIRECT_LD"; then
++  ac_cv_prog_DIRECT_LD="$DIRECT_LD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_DIRECT_LD="$target_alias-ld"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++DIRECT_LD=$ac_cv_prog_DIRECT_LD
++if test -n "$DIRECT_LD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DIRECT_LD" >&5
++printf "%s\n" "$DIRECT_LD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++if test -z "$ac_cv_prog_DIRECT_LD"; then
++  if test "$build" = "$target"; then
++    ac_ct_DIRECT_LD=$DIRECT_LD
++    # Extract the first word of "ld", so it can be a program name with args.
++set dummy ld; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_DIRECT_LD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$ac_ct_DIRECT_LD"; then
++  ac_cv_prog_ac_ct_DIRECT_LD="$ac_ct_DIRECT_LD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_DIRECT_LD="ld"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++  test -z "$ac_cv_prog_ac_ct_DIRECT_LD" && ac_cv_prog_ac_ct_DIRECT_LD="false"
++fi
++fi
++ac_ct_DIRECT_LD=$ac_cv_prog_ac_ct_DIRECT_LD
++if test -n "$ac_ct_DIRECT_LD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DIRECT_LD" >&5
++printf "%s\n" "$ac_ct_DIRECT_LD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++    DIRECT_LD=$ac_ct_DIRECT_LD
++  else
++    DIRECT_LD="false"
++  fi
++else
++  DIRECT_LD="$ac_cv_prog_DIRECT_LD"
++fi
++
++else $as_nop
++  if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}ld", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}ld; ac_word=$2
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+@@ -16452,9 +16662,10 @@ else
+   DIRECT_LD="$ac_cv_prog_DIRECT_LD"
+ fi
+ 
++fi
+ if test -z "$PARTIALLD"
+ then :
+-  case "$host,$ocaml_cc_vendor" in #(
++  case "$target,$ocaml_cc_vendor" in #(
+   x86_64-*-darwin*,gcc-*) :
+     PACKLD_FLAGS=' -arch x86_64' ;; #(
+   powerpc64le*-*-linux*,gcc-*) :
+@@ -16501,7 +16712,7 @@ case $arch in #(
+     # ocamlopt generates PIC code or doesn't generate code at all
+      ;; #(
+   *) :
+-    case $host in #(
++    case $target in #(
+   # expected to match "*-linux-musl" as well as "*-linux-musleabi*"
+     *-linux-musl*) :
+     # Alpine and other musl-based Linux distributions
+@@ -16704,7 +16915,7 @@ then :
+ printf %s "checking whether round works... " >&6; }
+ 
+   old_cross_compiling="$cross_compiling"
+-  if test "x$host_runnable" = 'xtrue'
++  if test "x$target_runnable" = 'xtrue'
+ then :
+   cross_compiling='no'
+ fi
+@@ -16776,7 +16987,7 @@ fi
+ printf %s "checking whether fma works... " >&6; }
+ 
+   old_cross_compiling="$cross_compiling"
+-  if test "x$host_runnable" = 'xtrue'
++  if test "x$target_runnable" = 'xtrue'
+ then :
+   cross_compiling='no'
+ fi
+@@ -16937,7 +17148,7 @@ fi
+ ## On Unix platforms, we check for the appropriate POSIX feature-test macros.
+ ## On MacOS clock_gettime's CLOCK_MONOTONIC flag is not actually monotonic.
+ 
+-case $host in #(
++case $target in #(
+   *-*-windows) :
+     has_monotonic_clock=true ;; #(
+   *-apple-darwin*) :
+@@ -17000,7 +17211,7 @@ esac
+ if test "x$enable_instrumented_runtime" != "xno"
+ then :
+ 
+-    case $host in #(
++    case $target in #(
+   sparc-sun-solaris*) :
+     instrumented_runtime=false ;; #(
+   *-*-windows) :
+@@ -17386,7 +17597,7 @@ fi
+ 
+ sockets=true
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*) :
+     cclibs="$cclibs -lws2_32"
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
+@@ -17734,7 +17945,7 @@ fi
+ 
+ ## socklen_t
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+     ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <ws2tcpip.h>
+ "
+@@ -17765,7 +17976,7 @@ fi
+ 
+ ## Unix domain sockets support on Windows
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+            for ac_header in afunix.h
+ do :
+@@ -17787,7 +17998,7 @@ esac
+ 
+ ipv6=true
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+     ac_fn_c_check_type "$LINENO" "struct sockaddr_in6" "ac_cv_type_struct_sockaddr_in6" "#include <ws2tcpip.h>
+ "
+@@ -17885,7 +18096,7 @@ fi
+ ## Note: this was defined in config/s-nt.h but the autoconf macros do not
+ # seem to detect it properly on Windows so we hardcode the definition
+ # of HAS_UTIME on Windows but this will probably need to be clarified
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+     printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
+  ;; #(
+@@ -18100,7 +18311,7 @@ fi
+ ## gethostname
+ # Note: detection fails on Windows so hardcoding the result
+ # (should be debugged later)
+-case $host in #(
++case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+     printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
+  ;; #(
+@@ -18156,7 +18367,7 @@ fi
+ 
+ ## setsid
+ 
+-case $host in #(
++case $target in #(
+   *-cygwin|*-*-mingw32*|*-pc-windows) :
+      ;; #(
+   *) :
+@@ -18197,7 +18408,7 @@ fi
+ ## newlocale() and <locale.h>
+ # Note: the detection fails on msvc so we hardcode the result
+ # (should be debugged later)
+-case $host in #(
++case $target in #(
+   *-pc-windows) :
+     printf "%s\n" "#define HAS_LOCALE_H 1" >>confdefs.h
+  ;; #(
+@@ -18252,7 +18463,7 @@ fi
+ ## strtod_l
+ # Note: not detected on MSVC so hardcoding the result
+ # (should be debugged later)
+-case $host in #(
++case $target in #(
+   *-pc-windows) :
+     printf "%s\n" "#define HAS_STRTOD_L 1" >>confdefs.h
+  ;; #(
+@@ -18269,7 +18480,7 @@ esac
+ ## shared library support
+ if $supports_shared_libraries
+ then :
+-  case $host in #(
++  case $target in #(
+   *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
+     DLLIBS="" ;; #(
+   *) :
+@@ -18369,7 +18580,7 @@ fi
+ 
+ 
+ ## -fdebug-prefix-map support by the C compiler
+-case $ocaml_cc_vendor,$host in #(
++case $ocaml_cc_vendor,$target in #(
+   *,*-*-mingw32*) :
+     cc_has_debug_prefix_map=false ;; #(
+   *,*-pc-windows) :
+@@ -18985,7 +19196,111 @@ fi
+ fi
+ 
+ 
+-if test -n "$ac_tool_prefix"; then
++if $cross_compiler
++then :
++  # Extract the first word of "$target_alias-pkg-config", so it can be a program name with args.
++set dummy $target_alias-pkg-config; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_PKG_CONFIG+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  case $PKG_CONFIG in
++  [\\/]* | ?:[\\/]*)
++  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
++  ;;
++  *)
++  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++  ;;
++esac
++fi
++PKG_CONFIG=$ac_cv_path_PKG_CONFIG
++if test -n "$PKG_CONFIG"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
++printf "%s\n" "$PKG_CONFIG" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++if test -z "$ac_cv_path_PKG_CONFIG"; then
++  if test "$build" = "$target"; then
++    ac_pt_PKG_CONFIG=$PKG_CONFIG
++    # Extract the first word of "pkg-config", so it can be a program name with args.
++set dummy pkg-config; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_path_ac_pt_PKG_CONFIG+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  case $ac_pt_PKG_CONFIG in
++  [\\/]* | ?:[\\/]*)
++  ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
++  ;;
++  *)
++  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++  test -z "$ac_cv_path_ac_pt_PKG_CONFIG" && ac_cv_path_ac_pt_PKG_CONFIG="false"
++  ;;
++esac
++fi
++ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
++if test -n "$ac_pt_PKG_CONFIG"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
++printf "%s\n" "$ac_pt_PKG_CONFIG" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++    PKG_CONFIG=$ac_pt_PKG_CONFIG
++  else
++    PKG_CONFIG="false"
++  fi
++else
++  PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
++fi
++
++else $as_nop
++  if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+ set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+@@ -19093,6 +19408,7 @@ else
+   PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
+ fi
+ 
++fi
+ 
+ ## ZSTD compression library
+ 
+@@ -19254,9 +19570,9 @@ fi
+ # library available, but not have the DLL in PATH. This then causes the build to
+ # fail as soon as ocamlrun is first executed. This check avoids automatically
+ # enabling zstd when the resulting executable doesn't actually work.
+-case $host in #(
++case $target in #(
+   *-w64-mingw32*|*-pc-windows) :
+-    check_zstd_runs=$host_runnable ;; #(
++    check_zstd_runs=$target_runnable ;; #(
+   *) :
+     check_zstd_runs=false ;;
+ esac
+@@ -19390,7 +19706,7 @@ esac
+ 
+ ## Determine how to link with the POSIX threads library
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*) :
+     link_gcc_eh=''
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for printf in -lgcc_eh" >&5
+@@ -20300,7 +20616,7 @@ as_has_debug_prefix_map=false
+ asm_cfi_supported=false
+ if $native_compiler
+ then :
+-  case $host in #(
++  case $target in #(
+   *-*-mingw32*|*-pc-windows) :
+      ;; #(
+   *) :
+@@ -20473,7 +20789,7 @@ fi
+ 
+ if test x"$enable_frame_pointers" = "xyes"
+ then :
+-  case $host in #(
++  case $target in #(
+   x86_64-*-linux*|x86_64-*-darwin*) :
+     case $ocaml_cc_vendor in #(
+   clang-*|gcc-*) :
+@@ -20918,7 +21234,7 @@ native_cflags="$native_cflags $PTHREAD_CFLAGS $COMPILER_NATIVE_CFLAGS"
+ bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
+ native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
+ 
+-case $host in #(
++case $target in #(
+   *-*-mingw32*) :
+     cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization" ;; #(
+   *-pc-windows) :
+@@ -20958,22 +21274,18 @@ then :
+      ;;
+ esac
+ else $as_nop
+-  if test x"$unix_or_win32" = "xwin32" \
+-          && test "$host_vendor-$host_os" != "$build_vendor-$build_os"
+-then :
+-  case $build in #(
+-  *-pc-cygwin) :
++  case $build,$host in #(
++  *-pc-cygwin,*-*-mingw32*|*-pc-cygwin,*-pc-windows) :
+     prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")" ;; #(
+   *) :
+      ;;
+ esac
+ fi
+-fi
+ 
+ # Define a few macros that were defined in config/m-nt.h
+ # but whose value is not guessed properly by configure
+ # (all this should be understood and fixed)
+-case $host in #(
++case $target in #(
+   *-*-mingw32*) :
+     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
+ 
 diff --git a/configure.ac b/configure.ac
 index 18b0681d26..75429a8b34 100644
 --- a/configure.ac

--- a/patches/5.3.0/0003-Detect-a-_build_-C-toolchain-to-build-sak.patch
+++ b/patches/5.3.0/0003-Detect-a-_build_-C-toolchain-to-build-sak.patch
@@ -229,58 +229,1230 @@ index 0000000000..1db8d73f96
 +AC_SUBST([LDFLAGS_FOR_BUILD])dnl
 +])
 diff --git a/configure b/configure
-index 9ef0edf50277e5cfc17ad978deef969df774805a..25fce20f5070b041a94ddd51d4899489eab79ac4 100755
-GIT binary patch
-delta 6946
-zcmds6eM}t371unt57r+sB?cRU8P;bwFo%s}^I<r??hb;%HnAO>N+_%2Sjffn4s(Zr
-zPz$GR8oN~!TO>?cw~6hls+vZYt0-NiB$8>GrXNugSE}T+jVmjS6}KUzsolzQQ+IZE
-z_ICEbl?$PN_@tBGn~yi|{pQV^H*f#>f%}zDi_ad}G1lg9YHMiTEj8`jB{e?K(&iU@
-z?d`Lgk{h&<($2<hfsQ?b&ICFFDnn;;vVtKg6qkHHuF1;0cyvd5TK4XSR;jIJN2{O`
-zK5a3b^nLllKIOtbbUFX=$q_{VK>sQ9pQ=ob*!-u)?u!oLcocUHhWom4EVy3~!aX=H
-z$KrTcbZM<3_NsI|IM6G{MeK>1oHQ^Pi3Gd)WNl1*U{Ds~56Ka{Rlr!&#OEz^xqZH(
-zLfXKZH09Lhoj$7RHWj-fOb2Q0Dy6nF1ho!>Hf5-msuH%hQp}{iEe#Z)qC)bc=WVrX
-zyXCkXiiab;m}-K3)V63}=%HXZf_tI^x|w9^J;)uqje#PrEhw)(BnU!iAR3EFq39R-
-z!+lh?qygiNL<NCvkj6;rLQ?;L+!G%5CNT6wuz{k9j5ei*;%%A3#(6|R?lZQ)oGu0X
-z!oirBB;*z{^ubh8PnaC<bY^v#-h*8Rwq{$QYJ_f^Okw5y3wuIzMw0W+C4=O@<;)^8
-zozA6_DOmNDP&Cq`x|1sblsqiU!|~e_i(Rvh7dbX<+q_Z7JfZf0)EgP3`!p1cNijJt
-zSv$P0QF5{j?%uL~<WOR3T%&UjK4fAX3m%laC30rkw$85l?<m&9q<O3HV1zECvo`7>
-zcP!904QTSUiwHCF_!}sby!|4SlIe@6hBdnXgr0XA8&BHTIRb*|M&$f!C~LLJxB0yy
-z=Vi*NV#i*zDye_e@E7vrC3LddkWJ^Ro)kJrk6N_X8W=67#uP{J&ykN;=j5-^DxN>~
-zHj0vO45s9io0Ho7VznAUA~bNR>se#4ms7vZPwKx4n1tU$zqdj_@`h6E{6Z9m+&q2_
-zibJw+6^%}mZXMMd3X$OJ=&7ZAGdX`0GI;S*C5}v<r*^mSylOY;zihMUM2(M-u}4xe
-zih0>uJWl|CG2iDE$=ItP+V!|cPQ40)%nJ^DfOau5{m-yrw`JBWOX*FCaZi|ryO>NV
-z%U~UsIX0P~T1SQzhRQ2Q<b5-G1?^}2J6F&Ttb4-au`su+`w%_1*lu}%yfKYd3a0au
-zOZ_Q@B;_OY+xePBsDG_jq#2~3<)&P(sC(EEa{6!RFu$Pq3HmY5U-$%V<9YG#$g|im
-zXs2^U2Ja#4bdpOiLk8RI;8k>rk?0yaGhcx8aFoR_rXN#166Svhr@fZW#fV1-=%oWo
-zt$zNS$3UECgi`9Sqda6qWC78MKSU3{g-%-a{H(&#qx>@I=TX6DAEB&4XO0L(T5qCz
-z(#>-+hufL=;m>ZOTHOJkM(~0aZQhoJ#hr%%PXAvH+`_KIrc}6Sg<t^=_c_af6GMH$
-z2nkL)pCmJ{Bm3fb-(p>gV-{29aJhM0ifW=SXn#R_xp^L;uMU145f>ED>~$3P4=8Q{
-zGE+&)mr%t-o_(p}-vGZuENnKELm{avgX`N(kN1wqG2@DE=4E=-1!?x8uE?I8G|x_c
-zE2tSaSySQ6<nN61D~|eQ76r+<O|X$4^6@5cGp(}jg`<po?q0~^PNP@!^ojx|mp--y
-zNdGn1M>Yn)&c;5t8C;edP80}!*4d&Ce1LqX(z$}1{jMXGRBnNiSu)ee@xM4u@Zy$~
-zLxl;`&e`PgzdDMDy#m6lD^dXkj2y3kD&Dv^E5OKDrs=2>6Kyr`qJZ<6SJLB)tgnO|
-zURYBl<dyy}5@`Omu@WpB@^mG9g_pUy3hI*hHRPK<$W7PZU0UuPqG@qi8JY5d@d|jS
-z3f6Gb#?g%ck^FEMY26B2xDIl7E3`0dez6t2j64uXAXZcjwfux{)h7@;QVri{6H05~
-zJR|>I1McQo%IObye2AVY`m=bi^?+b@iR*X#b}x9C+z~Gv;}uD(wIV}#9hntLi&v3z
-zzJz7Jq@y?~31BAnAb||~A)82bu!kGLBXpxKA%{b#v;LL{P1Yw63N|DVDr-!fsE$Us
-zr@(X>%WJI7Z^hzpV*-m88m(B=_^en^UdMuA_mU6pW8}YR7iXRUz!O{>Z}OJFTqaKh
-zZfWwhK*Hn`O$n3tH_vv8%Bp!f#ZQ_OKwNHyx;w9?(x`i|wRA#jD#o+=HVP(Mc_iEG
-z(hDa^lIV3o8lG|lCW@hiY!qR+^2%~ZcQ6lmb0y?3^72Z<Q<Y_za1iC|is^MDH9|(B
-z>V2k{0kl5lnJnl?S<R0#$^=>)`7|3Ub?M6H9Qa2HTZxMID0}l@uW<wZ5JQ0V&0tu|
-z$n<<DFXn}tRX<%RuZu6?Qt$SYb7$>Klr#D8E@BU5<?Cx<oUNneuA_DtFX-_Ca2xbw
-z0bqmvLjk<+(3UMMB~#<}3Uad$b{W0*yJ4L{uga$dhzU2WU<!ZF4OL`d7u1mLMUY80
-z6v6#^k1|#SIVownEzz!rNqQ!%QeG;7ZyN}-m%`_nl&STpcaywl9d|MQSEaCq!9b_d
-z8lDM*&Kof3W$in(^vJ+?ZQAyJrx`=F3`<YGy4B>1FXFRDgIeR@o3#YWI9z(l#&?rH
-zeq_sDrtg$q>uM+Y-B3X`&)DiWm@8vi+D^L6JOMGONqKC>b|SUbBCVZPvG@hG3^G|q
-z%e`28)s~g}Uu6&!g6bulSfUo4mT?Vje&yw>wlo_b`G0!d)^+E_Q|2g-u5@OQ@lNNv
-zV}h23u<s()Eu&d1{h1$c)GIkD@tdpau1{NwcSPedtyTu(xY*Ml@(hI|-O-^K4##My
-zjN{l~e}8l!-XV8u-$2;+3LJ~#AsL5)5j+@^aiJ$V`vZ%vtNInjRINy@>bu-!YU?KY
-aVW%hj_>F8k{X6L2N&jiejcnnItN#OTd!9M~
-
-delta 67
-zcmdn<SL^!=jSU@so7wyWIh%_jwiiV(K2>aws$v9UCLm@8VwUYuRjiH++g+Bj0Wmue
-Oa{w{tc9*4G6_NnX^BSoD
-
+index 9ef0edf502..25fce20f50 100755
+--- a/configure
++++ b/configure
+@@ -730,6 +730,14 @@ INSTALL_DATA
+ INSTALL_SCRIPT
+ INSTALL_PROGRAM
+ flexlink
++LDFLAGS_FOR_BUILD
++CPPFLAGS_FOR_BUILD
++CFLAGS_FOR_BUILD
++BUILD_OBJEXT
++BUILD_EXEEXT
++CPP_FOR_BUILD
++ac_ct_CC_FOR_BUILD
++CC_FOR_BUILD
+ CPP
+ ac_ct_DEP_CC
+ DEP_CC
+@@ -913,6 +921,9 @@ ac_tool_prefix
+ CSCFLAGS
+ CSC
+ DIFF_FLAGS
++SAK_LINK
++SAK_CFLAGS
++SAK_CC
+ CC
+ LINEAR_MAGIC_NUMBER
+ CMT_MAGIC_NUMBER
+@@ -3387,6 +3398,9 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
+ 
+ 
+ 
++
++
++
+ # Note: This is present for the flexdll bootstrap where it exposed as the old
+ # TOOLPREF variable. It would be better if flexdll where updated to require
+ # WINDRES instead.
+@@ -14084,6 +14098,1185 @@ fi
+ ac_config_commands="$ac_config_commands shebang"
+ 
+ 
++# How to build sak
++
++if test x"$build" = x"$target" -o x"$target_runnable" = xtrue
++then :
++  SAK_CC='$(CC)'
++    SAK_CFLAGS='$(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS)'
++    SAK_LINK='$(MKEXE_VIA_CC)'
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: detecting the C toolchain for build" >&5
++printf "%s\n" "$as_me: detecting the C toolchain for build" >&6;}
++
++
++cross_compiling_build=no
++
++ac_build_tool_prefix=
++if test -n "$build"
++then :
++  ac_build_tool_prefix="$build-"
++elif test -n "$build_alias"
++then :
++  ac_build_tool_prefix="$build_alias-"
++fi
++
++ac_ext=c
++ac_cpp='$CPP_FOR_BUILD $CPPFLAGS_FOR_BUILD'
++ac_compile='$CC_FOR_BUILD -c $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD conftest.$ac_ext >&5'
++ac_link='$CC_FOR_BUILD -o conftest$ac_build_exeext $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD $LDFLAGS_FOR_BUILD conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_build_c_compiler_gnu
++
++
++was_set_c_compiler_gnu=${ac_cv_c_compiler_gnu+y}
++if test ${was_set_c_compiler_gnu}
++then :
++  saved_c_compiler_gnu=$ac_cv_c_compiler_gnu
++    { ac_cv_c_compiler_gnu=; unset ac_cv_c_compiler_gnu;}
++fi
++
++ac_ext=c
++ac_cpp='$CPP_FOR_BUILD $CPPFLAGS_FOR_BUILD'
++ac_compile='$CC_FOR_BUILD -c $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD conftest.$ac_ext >&5'
++ac_link='$CC_FOR_BUILD -o conftest$ac_build_exeext $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD $LDFLAGS_FOR_BUILD conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_build_c_compiler_gnu
++if test -n "$ac_build_tool_prefix"; then
++  # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
++set dummy ${ac_build_tool_prefix}gcc; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$CC_FOR_BUILD"; then
++  ac_cv_prog_CC_FOR_BUILD="$CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_CC_FOR_BUILD="${ac_build_tool_prefix}gcc"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++CC_FOR_BUILD=$ac_cv_prog_CC_FOR_BUILD
++if test -n "$CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC_FOR_BUILD" >&5
++printf "%s\n" "$CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++fi
++if test -z "$ac_cv_prog_CC_FOR_BUILD"; then
++  ac_ct_CC_FOR_BUILD=$CC_FOR_BUILD
++  # Extract the first word of "gcc", so it can be a program name with args.
++set dummy gcc; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$ac_ct_CC_FOR_BUILD"; then
++  ac_cv_prog_ac_ct_CC_FOR_BUILD="$ac_ct_CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_CC_FOR_BUILD="gcc"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++ac_ct_CC_FOR_BUILD=$ac_cv_prog_ac_ct_CC_FOR_BUILD
++if test -n "$ac_ct_CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC_FOR_BUILD" >&5
++printf "%s\n" "$ac_ct_CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++  if test "x$ac_ct_CC_FOR_BUILD" = x; then
++    CC_FOR_BUILD=""
++  else
++    case $cross_compiling_build:$ac_tool_warned in
++yes:)
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with build triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with build triplet" >&2;}
++ac_tool_warned=yes ;;
++esac
++    CC_FOR_BUILD=$ac_ct_CC_FOR_BUILD
++  fi
++else
++  CC_FOR_BUILD="$ac_cv_prog_CC_FOR_BUILD"
++fi
++
++if test -z "$CC_FOR_BUILD"; then
++          if test -n "$ac_build_tool_prefix"; then
++    # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
++set dummy ${ac_build_tool_prefix}cc; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$CC_FOR_BUILD"; then
++  ac_cv_prog_CC_FOR_BUILD="$CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_CC_FOR_BUILD="${ac_build_tool_prefix}cc"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++CC_FOR_BUILD=$ac_cv_prog_CC_FOR_BUILD
++if test -n "$CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC_FOR_BUILD" >&5
++printf "%s\n" "$CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++  fi
++fi
++if test -z "$CC_FOR_BUILD"; then
++  # Extract the first word of "cc", so it can be a program name with args.
++set dummy cc; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$CC_FOR_BUILD"; then
++  ac_cv_prog_CC_FOR_BUILD="$CC_FOR_BUILD" # Let the user override the test.
++else
++  ac_prog_rejected=no
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    if test "$as_dir$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
++       ac_prog_rejected=yes
++       continue
++     fi
++    ac_cv_prog_CC_FOR_BUILD="cc"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++if test $ac_prog_rejected = yes; then
++  # We found a bogon in the path, so make sure we never use it.
++  set dummy $ac_cv_prog_CC_FOR_BUILD
++  shift
++  if test $# != 0; then
++    # We chose a different compiler from the bogus one.
++    # However, it has the same basename, so the bogon will be chosen
++    # first if we set CC_FOR_BUILD to just the basename; use the full file name.
++    shift
++    ac_cv_prog_CC_FOR_BUILD="$as_dir$ac_word${1+' '}$@"
++  fi
++fi
++fi
++fi
++CC_FOR_BUILD=$ac_cv_prog_CC_FOR_BUILD
++if test -n "$CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC_FOR_BUILD" >&5
++printf "%s\n" "$CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++fi
++if test -z "$CC_FOR_BUILD"; then
++  if test -n "$ac_build_tool_prefix"; then
++  for ac_prog in cl.exe
++  do
++    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
++set dummy $ac_build_tool_prefix$ac_prog; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$CC_FOR_BUILD"; then
++  ac_cv_prog_CC_FOR_BUILD="$CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_CC_FOR_BUILD="$ac_build_tool_prefix$ac_prog"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++CC_FOR_BUILD=$ac_cv_prog_CC_FOR_BUILD
++if test -n "$CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC_FOR_BUILD" >&5
++printf "%s\n" "$CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++    test -n "$CC_FOR_BUILD" && break
++  done
++fi
++if test -z "$CC_FOR_BUILD"; then
++  ac_ct_CC_FOR_BUILD=$CC_FOR_BUILD
++  for ac_prog in cl.exe
++do
++  # Extract the first word of "$ac_prog", so it can be a program name with args.
++set dummy $ac_prog; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$ac_ct_CC_FOR_BUILD"; then
++  ac_cv_prog_ac_ct_CC_FOR_BUILD="$ac_ct_CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_CC_FOR_BUILD="$ac_prog"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++ac_ct_CC_FOR_BUILD=$ac_cv_prog_ac_ct_CC_FOR_BUILD
++if test -n "$ac_ct_CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC_FOR_BUILD" >&5
++printf "%s\n" "$ac_ct_CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++  test -n "$ac_ct_CC_FOR_BUILD" && break
++done
++
++  if test "x$ac_ct_CC_FOR_BUILD" = x; then
++    CC_FOR_BUILD=""
++  else
++    case $cross_compiling_build:$ac_tool_warned in
++yes:)
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with build triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with build triplet" >&2;}
++ac_tool_warned=yes ;;
++esac
++    CC_FOR_BUILD=$ac_ct_CC_FOR_BUILD
++  fi
++fi
++
++fi
++if test -z "$CC_FOR_BUILD"; then
++  if test -n "$ac_build_tool_prefix"; then
++  # Extract the first word of "${ac_tool_prefix}clang", so it can be a program name with args.
++set dummy ${ac_build_tool_prefix}clang; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$CC_FOR_BUILD"; then
++  ac_cv_prog_CC_FOR_BUILD="$CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_CC_FOR_BUILD="${ac_build_tool_prefix}clang"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++CC_FOR_BUILD=$ac_cv_prog_CC_FOR_BUILD
++if test -n "$CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC_FOR_BUILD" >&5
++printf "%s\n" "$CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++
++fi
++if test -z "$ac_cv_prog_CC_FOR_BUILD"; then
++  ac_ct_CC_FOR_BUILD=$CC_FOR_BUILD
++  # Extract the first word of "clang", so it can be a program name with args.
++set dummy clang; ac_word=$2
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++printf %s "checking for $ac_word... " >&6; }
++if test ${ac_cv_prog_ac_ct_CC_FOR_BUILD+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  if test -n "$ac_ct_CC_FOR_BUILD"; then
++  ac_cv_prog_ac_ct_CC_FOR_BUILD="$ac_ct_CC_FOR_BUILD" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  case $as_dir in #(((
++    '') as_dir=./ ;;
++    */) ;;
++    *) as_dir=$as_dir/ ;;
++  esac
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_CC_FOR_BUILD="clang"
++    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++ac_ct_CC_FOR_BUILD=$ac_cv_prog_ac_ct_CC_FOR_BUILD
++if test -n "$ac_ct_CC_FOR_BUILD"; then
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC_FOR_BUILD" >&5
++printf "%s\n" "$ac_ct_CC_FOR_BUILD" >&6; }
++else
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++fi
++
++  if test "x$ac_ct_CC_FOR_BUILD" = x; then
++    CC_FOR_BUILD=""
++  else
++    case $cross_compiling_build:$ac_tool_warned in
++yes:)
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with build triplet" >&5
++printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with build triplet" >&2;}
++ac_tool_warned=yes ;;
++esac
++    CC_FOR_BUILD=$ac_ct_CC_FOR_BUILD
++  fi
++else
++  CC_FOR_BUILD="$ac_cv_prog_CC_FOR_BUILD"
++fi
++
++fi
++
++
++test -z "$CC_FOR_BUILD" && { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "no acceptable C compiler found in \$PATH
++See \`config.log' for more details" "$LINENO" 5; }
++
++# Provide some information about the compiler.
++printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
++set X $ac_compile
++ac_compiler=$2
++for ac_option in --version -v -V -qversion -version; do
++  { { ac_try="$ac_compiler $ac_option >&5"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++printf "%s\n" "$ac_try_echo"; } >&5
++  (eval "$ac_compiler $ac_option >&5") 2>conftest.err
++  ac_status=$?
++  if test -s conftest.err; then
++    sed '10a\
++... rest of stderr output deleted ...
++         10q' conftest.err >conftest.er1
++    cat conftest.er1 >&5
++  fi
++  rm -f conftest.er1 conftest.err
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++done
++
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports GNU C" >&5
++printf %s "checking whether the compiler supports GNU C... " >&6; }
++if test ${ac_cv_c_compiler_gnu+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++#ifndef __GNUC__
++       choke me
++#endif
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_compiler_gnu=yes
++else $as_nop
++  ac_compiler_gnu=no
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam conftest.$ac_ext
++ac_cv_c_compiler_gnu=$ac_compiler_gnu
++
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
++printf "%s\n" "$ac_cv_c_compiler_gnu" >&6; }
++ac_compiler_gnu=$ac_cv_c_compiler_gnu
++
++if test $ac_compiler_gnu = yes; then
++  GCC_FOR_BUILD=yes
++else
++  GCC_FOR_BUILD=
++fi
++ac_test_CFLAGS=${CFLAGS_FOR_BUILD+y}
++ac_save_CFLAGS=$CFLAGS_FOR_BUILD
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC_FOR_BUILD accepts -g" >&5
++printf %s "checking whether $CC_FOR_BUILD accepts -g... " >&6; }
++if test ${ac_cv_build_prog_cc_g+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_save_c_werror_flag=$ac_c_werror_flag
++   ac_c_werror_flag=yes
++   ac_cv_build_prog_cc_g=no
++   CFLAGS_FOR_BUILD="-g"
++   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_build_prog_cc_g=yes
++else $as_nop
++  CFLAGS_FOR_BUILD=""
++      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++
++else $as_nop
++  ac_c_werror_flag=$ac_save_c_werror_flag
++	 CFLAGS_FOR_BUILD="-g"
++	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_build_prog_cc_g=yes
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam conftest.$ac_ext
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam conftest.$ac_ext
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam conftest.$ac_ext
++   ac_c_werror_flag=$ac_save_c_werror_flag
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build_prog_cc_g" >&5
++printf "%s\n" "$ac_cv_build_prog_cc_g" >&6; }
++if test $ac_test_CFLAGS; then
++  CFLAGS_FOR_BUILD=$ac_save_CFLAGS
++elif test $ac_cv_build_prog_cc_g = yes; then
++  if test "$GCC_FOR_BUILD" = yes; then
++    CFLAGS_FOR_BUILD="-g -O2"
++  else
++    CFLAGS_FOR_BUILD="-g"
++  fi
++else
++  if test "$GCC_FOR_BUILD" = yes; then
++    CFLAGS_FOR_BUILD="-O2"
++  else
++    CFLAGS_FOR_BUILD=
++  fi
++fi
++ac_prog_cc_stdc=no
++if test x$ac_prog_cc_stdc = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC_FOR_BUILD option to enable C11 features" >&5
++printf %s "checking for $CC_FOR_BUILD option to enable C11 features... " >&6; }
++if test ${ac_cv_build_prog_cc_c11+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_build_prog_cc_c11=no
++ac_save_CC=$CC_FOR_BUILD
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_c_conftest_c11_program
++_ACEOF
++for ac_arg in '' -std=gnu11
++do
++  CC_FOR_BUILD="$ac_save_CC $ac_arg"
++  if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_build_prog_cc_c11=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam
++  test "x$ac_cv_build_prog_cc_c11" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CC_FOR_BUILD=$ac_save_CC
++fi
++
++if test "x$ac_cv_build_prog_cc_c11" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_build_prog_cc_c11" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build_prog_cc_c11" >&5
++printf "%s\n" "$ac_cv_build_prog_cc_c11" >&6; }
++     CC_FOR_BUILD="$CC_FOR_BUILD $ac_cv_build_prog_cc_c11"
++fi
++  ac_cv_prog_cc_stdc=$ac_cv_build_prog_cc_c11
++  ac_prog_cc_stdc=c11
++fi
++fi
++if test x$ac_prog_cc_stdc = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC_FOR_BUILD option to enable C99 features" >&5
++printf %s "checking for $CC_FOR_BUILD option to enable C99 features... " >&6; }
++if test ${ac_cv_build_prog_cc_c99+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_build_prog_cc_c99=no
++ac_save_CC=$CC_FOR_BUILD
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_c_conftest_c99_program
++_ACEOF
++for ac_arg in '' -std=gnu99 -std=c99 -c99 -qlanglvl=extc1x -qlanglvl=extc99 -AC99 -D_STDC_C99=
++do
++  CC_FOR_BUILD="$ac_save_CC $ac_arg"
++  if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_build_prog_cc_c99=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam
++  test "x$ac_cv_build_prog_cc_c99" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CC_FOR_BUILD=$ac_save_CC
++fi
++
++if test "x$ac_cv_build_prog_cc_c99" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_build_prog_cc_c99" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build_prog_cc_c99" >&5
++printf "%s\n" "$ac_cv_build_prog_cc_c99" >&6; }
++     CC_FOR_BUILD="$CC_FOR_BUILD $ac_cv_build_prog_cc_c99"
++fi
++  ac_cv_prog_cc_stdc=$ac_cv_build_prog_cc_c99
++  ac_prog_cc_stdc=c99
++fi
++fi
++if test x$ac_prog_cc_stdc = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC_FOR_BUILD option to enable C89 features" >&5
++printf %s "checking for $CC_FOR_BUILD option to enable C89 features... " >&6; }
++if test ${ac_cv_build_prog_cc_c89+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_cv_build_prog_cc_c89=no
++ac_save_CC=$CC_FOR_BUILD
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++$ac_c_conftest_c89_program
++_ACEOF
++for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std -Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
++do
++  CC_FOR_BUILD="$ac_save_CC $ac_arg"
++  if ac_fn_c_try_compile "$LINENO"
++then :
++  ac_cv_build_prog_cc_c89=$ac_arg
++fi
++rm -f core conftest.err conftest.$ac_build_objext conftest.beam
++  test "x$ac_cv_build_prog_cc_c89" != "xno" && break
++done
++rm -f conftest.$ac_ext
++CC_FOR_BUILD=$ac_save_CC
++fi
++
++if test "x$ac_cv_build_prog_cc_c89" = xno
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
++printf "%s\n" "unsupported" >&6; }
++else $as_nop
++  if test "x$ac_cv_build_prog_cc_c89" = x
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
++printf "%s\n" "none needed" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build_prog_cc_c89" >&5
++printf "%s\n" "$ac_cv_build_prog_cc_c89" >&6; }
++     CC_FOR_BUILD="$CC_FOR_BUILD $ac_cv_build_prog_cc_c89"
++fi
++  ac_cv_prog_cc_stdc=$ac_cv_build_prog_cc_c89
++  ac_prog_cc_stdc=c89
++fi
++fi
++
++ac_ext=c
++ac_cpp='$CPP_FOR_BUILD $CPPFLAGS_FOR_BUILD'
++ac_compile='$CC_FOR_BUILD -c $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD conftest.$ac_ext >&5'
++ac_link='$CC_FOR_BUILD -o conftest$ac_build_exeext $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD $LDFLAGS_FOR_BUILD conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_build_c_compiler_gnu
++
++
++if test ${was_set_c_compiler_gnu}
++then :
++  ac_cv_c_compiler_gnu=$saved_c_compiler_gnu
++fi
++
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++ac_clean_files_save=$ac_clean_files
++ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
++# Try to create an executable without -o first, disregard a.out.
++# It will help us diagnose broken compilers, and finding out an intuition
++# of exeext.
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
++printf %s "checking whether the C compiler works... " >&6; }
++ac_link_default=`printf "%s\n" "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
++
++# The possible output files:
++ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
++
++ac_rmfiles=
++for ac_file in $ac_files
++do
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
++    * ) ac_rmfiles="$ac_rmfiles $ac_file";;
++  esac
++done
++rm -f $ac_rmfiles
++
++if { { ac_try="$ac_link_default"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++printf "%s\n" "$ac_try_echo"; } >&5
++  (eval "$ac_link_default") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++then :
++  # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
++# So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
++# in a Makefile.  We should not override ac_cv_exeext if it was cached,
++# so that the user can short-circuit this test for compilers unknown to
++# Autoconf.
++for ac_file in $ac_files ''
++do
++  test -f "$ac_file" || continue
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj )
++	;;
++    [ab].out )
++	# We found the default executable, but exeext='' is most
++	# certainly right.
++	break;;
++    *.* )
++	if test ${ac_cv_build_exeext+y} && test "$ac_cv_build_exeext" != no;
++	then :; else
++	   ac_cv_build_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
++	fi
++	# We set ac_cv_exeext here because the later test for it is not
++	# safe: cross compilers may not add the suffix if given an `-o'
++	# argument, so we may need to know it at that point already.
++	# Even if this section looks crufty: it has the advantage of
++	# actually working.
++	break;;
++    * )
++	break;;
++  esac
++done
++test "$ac_cv_build_exeext" = no && ac_cv_build_exeext=
++
++else $as_nop
++  ac_file=''
++fi
++if test -z "$ac_file"
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
++printf "%s\n" "no" >&6; }
++printf "%s\n" "$as_me: failed program was:" >&5
++sed 's/^/| /' conftest.$ac_ext >&5
++
++{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error 77 "C compiler cannot create executables
++See \`config.log' for more details" "$LINENO" 5; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++printf "%s\n" "yes" >&6; }
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
++printf %s "checking for C compiler default output file name... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
++printf "%s\n" "$ac_file" >&6; }
++ac_build_exeext=$ac_cv_build_exeext
++
++rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_build_exeext b.out
++ac_clean_files=$ac_clean_files_save
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
++printf %s "checking for suffix of executables... " >&6; }
++if { { ac_try="$ac_link"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++printf "%s\n" "$ac_try_echo"; } >&5
++  (eval "$ac_link") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++then :
++  # If both `conftest.exe' and `conftest' are `present' (well, observable)
++# catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
++# work properly (i.e., refer to `conftest.exe'), while it won't with
++# `rm'.
++for ac_file in conftest.exe conftest conftest.*; do
++  test -f "$ac_file" || continue
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
++    *.* ) ac_cv_build_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
++	  break;;
++    * ) break;;
++  esac
++done
++else $as_nop
++  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "cannot compute suffix of executables: cannot compile and link
++See \`config.log' for more details" "$LINENO" 5; }
++fi
++rm -f conftest conftest$ac_cv_build_exeext
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build_exeext" >&5
++printf "%s\n" "$ac_cv_build_exeext" >&6; }
++
++rm -f conftest.$ac_ext
++EXEEXT=$ac_cv_build_exeext
++ac_build_exeext=$BUILD_EXEEXT
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <stdio.h>
++int
++main (void)
++{
++FILE *f = fopen ("conftest.out", "w");
++ return ferror (f) || fclose (f) != 0;
++
++  ;
++  return 0;
++}
++_ACEOF
++ac_clean_files="$ac_clean_files conftest.out"
++# Check that the compiler produces executables we can run.  If not, either
++# the compiler is broken, or we cross compile.
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
++printf %s "checking whether we are cross compiling... " >&6; }
++if test "$cross_compiling_build" != yes; then
++  { { ac_try="$ac_link"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++printf "%s\n" "$ac_try_echo"; } >&5
++  (eval "$ac_link") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++  if { ac_try='./conftest$ac_cv_build_exeext'
++  { { case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++printf "%s\n" "$ac_try_echo"; } >&5
++  (eval "$ac_try") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }; then
++    cross_compiling_build=no
++  else
++    if test "$cross_compiling_build" = maybe; then
++	cross_compiling_build=yes
++    else
++	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error 77 "cannot run C compiled programs.
++If you meant to cross compile, use \`--build'.
++See \`config.log' for more details" "$LINENO" 5; }
++    fi
++  fi
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $cross_compiling_build" >&5
++printf "%s\n" "$cross_compiling_build" >&6; }
++
++rm -f conftest.$ac_ext conftest$ac_cv_build_exeext conftest.out
++ac_clean_files=$ac_clean_files_save
++
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
++printf %s "checking for suffix of object files... " >&6; }
++if test ${ac_cv_build_objext+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main (void)
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++rm -f conftest.o conftest.obj
++if { { ac_try="$ac_compile"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++printf "%s\n" "$ac_try_echo"; } >&5
++  (eval "$ac_compile") 2>&5
++  ac_status=$?
++  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++then :
++  for ac_file in conftest.o conftest.obj conftest.*; do
++  test -f "$ac_file" || continue;
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM ) ;;
++    *) ac_cv_build_objext=`expr "$ac_file" : '.*\.\(.*\)'`
++       break;;
++  esac
++done
++else $as_nop
++  printf "%s\n" "$as_me: failed program was:" >&5
++sed 's/^/| /' conftest.$ac_ext >&5
++
++{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "cannot compute suffix of object files: cannot compile
++See \`config.log' for more details" "$LINENO" 5; }
++fi
++rm -f conftest.$ac_cv_build_objext conftest.$ac_ext
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build_objext" >&5
++printf "%s\n" "$ac_cv_build_objext" >&6; }
++OBJEXT=$ac_cv_build_objext
++ac_build_objext=$BUILD_OBJEXT
++
++ac_ext=c
++ac_cpp='$CPP_FOR_BUILD $CPPFLAGS_FOR_BUILD'
++ac_compile='$CC_FOR_BUILD -c $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD conftest.$ac_ext >&5'
++ac_link='$CC_FOR_BUILD -o conftest$ac_build_exeext $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD $LDFLAGS_FOR_BUILD conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_build_c_compiler_gnu
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
++printf %s "checking how to run the C preprocessor... " >&6; }
++# On Suns, sometimes $CPP names a directory.
++if test -n "$CPP_FOR_BUILD" && test -d "$CPP_FOR_BUILD"; then
++  CPP_FOR_BUILD=
++fi
++if test -z "$CPP_FOR_BUILD"; then
++  if test ${ac_cv_build_prog_CPP+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++      # Double quotes because $CC needs to be expanded
++    for CPP_FOR_BUILD in "$CC_FOR_BUILD -E" "$CC_FOR_BUILD -E -traditional-cpp" cpp /lib/cpp
++    do
++      ac_preproc_ok=false
++for ac_c_preproc_warn_flag in '' yes
++do
++  # Use a header file that comes with gcc, so configuring glibc
++  # with a fresh cross-compiler works.
++  # On the NeXT, cc -E runs the code through the compiler's parser,
++  # not just through cpp. "Syntax error" is here to catch this case.
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <limits.h>
++		     Syntax error
++_ACEOF
++if ac_fn_c_try_cpp "$LINENO"
++then :
++
++else $as_nop
++  # Broken: fails on valid input.
++continue
++fi
++rm -f conftest.err conftest.i conftest.$ac_ext
++
++  # OK, works on sane cases.  Now check whether nonexistent headers
++  # can be detected and how.
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <ac_nonexistent.h>
++_ACEOF
++if ac_fn_c_try_cpp "$LINENO"
++then :
++  # Broken: success on invalid input.
++continue
++else $as_nop
++  # Passes both tests.
++ac_preproc_ok=:
++break
++fi
++rm -f conftest.err conftest.i conftest.$ac_ext
++
++done
++# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
++rm -f conftest.i conftest.err conftest.$ac_ext
++if $ac_preproc_ok
++then :
++  break
++fi
++
++    done
++    ac_cv_build_prog_CPP=$CPP_FOR_BUILD
++
++fi
++  CPP_FOR_BUILD=$ac_cv_build_prog_CPP
++else
++  ac_cv_build_prog_CPP=$CPP_FOR_BUILD
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CPP_FOR_BUILD" >&5
++printf "%s\n" "$CPP_FOR_BUILD" >&6; }
++ac_preproc_ok=false
++for ac_c_preproc_warn_flag in '' yes
++do
++  # Use a header file that comes with gcc, so configuring glibc
++  # with a fresh cross-compiler works.
++  # On the NeXT, cc -E runs the code through the compiler's parser,
++  # not just through cpp. "Syntax error" is here to catch this case.
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <limits.h>
++		     Syntax error
++_ACEOF
++if ac_fn_c_try_cpp "$LINENO"
++then :
++
++else $as_nop
++  # Broken: fails on valid input.
++continue
++fi
++rm -f conftest.err conftest.i conftest.$ac_ext
++
++  # OK, works on sane cases.  Now check whether nonexistent headers
++  # can be detected and how.
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <ac_nonexistent.h>
++_ACEOF
++if ac_fn_c_try_cpp "$LINENO"
++then :
++  # Broken: success on invalid input.
++continue
++else $as_nop
++  # Passes both tests.
++ac_preproc_ok=:
++break
++fi
++rm -f conftest.err conftest.i conftest.$ac_ext
++
++done
++# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
++rm -f conftest.i conftest.err conftest.$ac_ext
++if $ac_preproc_ok
++then :
++
++else $as_nop
++  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "C preprocessor \"$CPP_FOR_BUILD\" fails sanity check
++See \`config.log' for more details" "$LINENO" 5; }
++fi
++
++ac_ext=c
++ac_cpp='$CPP_FOR_BUILD $CPPFLAGS_FOR_BUILD'
++ac_compile='$CC_FOR_BUILD -c $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD conftest.$ac_ext >&5'
++ac_link='$CC_FOR_BUILD -o conftest$ac_build_exeext $CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD $LDFLAGS_FOR_BUILD conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_build_c_compiler_gnu
++
++
++
++ac_ext=c
++ac_cpp='$CPP $CPPFLAGS'
++ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
++ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
++ac_compiler_gnu=$ac_cv_c_compiler_gnu
++
++
++
++    SAK_CC="$CC_FOR_BUILD"
++    SAK_CFLAGS="$CFLAGS_FOR_BUILD $CPPFLAGS_FOR_BUILD"
++    # Note that *-pc-windows is not supported for _build_ so we can use '-o'
++    SAK_LINK='$(SAK_CC) $(SAK_CFLAGS) -o $(1) $(2)'
++fi
++
+ # Checks for programs
+ 
+ ## Check for the C compiler: done by libtool
 diff --git a/configure.ac b/configure.ac
 index 75429a8b34..f3a219ef9a 100644
 --- a/configure.ac

--- a/patches/5.3.0/0004-Check-that-the-OCaml-versions-are-compatible-for-a-c.patch
+++ b/patches/5.3.0/0004-Check-that-the-OCaml-versions-are-compatible-for-a-c.patch
@@ -14,19 +14,31 @@ tree and the C runtime from the non-cross compiler
  2 files changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 25fce20f5070b041a94ddd51d4899489eab79ac4..328a177641cce86671c394ddde17eae70192f3b1 100755
-GIT binary patch
-delta 483
-zcmdn<SF5vGyI~7s@?KMAh455`qSV6D%%W6<M1{QkJl*7?{NiGT<ow)%%$(FBh5R&y
-zl8jV^;>6rkg|gJ5;>`TK=^MYY+t_46Br@}gOA>Q(Qd1QCofC6&5E_#c^AwUwGjmeF
-z`cX}tp7@bjwjN|IS=#mV^c0j7?9|Mx6>7N@fFLoaC^a#qG9GSPJk+VSN-7%p$v}4{
-zE9jQxmF8+Hfz^ZDo~l(`qEMk^s%NZcprl|6WUAmaW_n^Qrz3Y|YO#U_SiR<S!)qK8
-z9B^J?3Y(usUOtqsP*$vf+bqrL4`(ons}ZU8<_$La=|8`+NiZoWv?uOm1Y#y2W(Hyw
-XAZ7((HXvpPVh$kY+@83XE1D4iLBFa)
-
-delta 53
-xcmeBd*5311t6>Xc^4@lX1B^h-1jNih%mT!$K+Fcj>_E%`#GKm=4sb;>0svWN6xRR%
-
+index 25fce20f50..328a177641 100755
+--- a/configure
++++ b/configure
+@@ -4266,7 +4266,20 @@ if test x"$host" = x"$target"
+ then :
+   cross_compiler=false
+ else $as_nop
+-  cross_compiler=true
++  # We require a non-cross compiler of the same version
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if the installed OCaml compiler can build the cross compiler" >&5
++printf %s "checking if the installed OCaml compiler can build the cross compiler... " >&6; }
++    already_installed_version="$(ocamlc -vnum)"
++    if test x"5.3.0" = x"$already_installed_version"
++then :
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes (5.3.0)" >&5
++printf "%s\n" "yes (5.3.0)" >&6; }
++else $as_nop
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (5.3.0 vs $already_installed_version)" >&5
++printf "%s\n" "no (5.3.0 vs $already_installed_version)" >&6; }
++      as_fn_error $? "exiting" "$LINENO" 5
++fi
++    cross_compiler=true
+ fi
+ 
+ # Initialization of libtool
 diff --git a/configure.ac b/configure.ac
 index f3a219ef9a..7e3b3a054e 100644
 --- a/configure.ac

--- a/patches/5.3.0/0005-Use-a-TARGET_BINDIR-configure-variable-instead-of-wi.patch
+++ b/patches/5.3.0/0005-Use-a-TARGET_BINDIR-configure-variable-instead-of-wi.patch
@@ -20,21 +20,96 @@ Suggested-by: David Allsopp <david.allsopp@metastack.com>
  2 files changed, 5 insertions(+), 8 deletions(-)
 
 diff --git a/configure b/configure
-index 328a177641cce86671c394ddde17eae70192f3b1..b9cd0229890350b736c804eaa7cc97a9e8910aef 100755
-GIT binary patch
-delta 252
-zcmeBd);`^+y+I*>H^ec>-8CfM$<xopGibAXfHmLd+&B{^H1P!qUlTU}KlqeQ1VufU
-z0vJqYJR~xC^+Bb{+K0F{KRLnlZ2HxFCdu{<>luNV35c12m<5PgftU@5*@2j2`-b(L
-z0<7971}Z7oDyUbebCqPI<|$YKjYpB){(1}N$68esF<W&Njnw3fd<7*H6!Gnh#$1;>
-NP`$DJ;cl)KtN<YjSrGsL
-
-delta 339
-zcmX@zsNLDDy+I*hvtED|A6rspUP@-s=IA&_rp>Doz9c{eCeJ=$G&ymPG+S|HaY<_K
-z=H7$f*fw83!Srmp%OXah>2KFD@<3HiXI#!GCRCnTk`Z5$Sd^Yx5)UzQ`owLF(w-<n
-z)(R+GTNRM5vcw#&)STi}1(n3&_`LiAE(J7I>grr+nOxHy7cq*q1MLN3CLm@8Viq7~
-z1!6WJW(Q)9?Qhp{in31sC(XvL0&#_sf~|sjg*sPBMrxjd6}s8mb+>SStd&D`mAZ;X
-rYH~)tf|3eEeEJVVE|u*GMqJxE*q|c&cX3HfzahgWvfX1hS2HUBFztl)
-
+index 328a177641..b9cd022989 100755
+--- a/configure
++++ b/configure
+@@ -772,6 +772,7 @@ ac_ct_LD
+ LD
+ DEFAULT_STRING
+ WINDOWS_UNICODE_MODE
++TARGET_BINDIR
+ LIBUNWIND_LDFLAGS
+ LIBUNWIND_CPPFLAGS
+ DLLIBS
+@@ -1019,7 +1020,6 @@ enable_native_compiler
+ enable_flambda
+ enable_flambda_invariants
+ enable_cmm_invariants
+-with_target_bindir
+ with_target_sh
+ enable_reserved_header_bits
+ enable_stdlib_manpages
+@@ -1054,6 +1054,7 @@ COMPILER_NATIVE_CPPFLAGS
+ DLLIBS
+ LIBUNWIND_CPPFLAGS
+ LIBUNWIND_LDFLAGS
++TARGET_BINDIR
+ WINDOWS_UNICODE_MODE
+ DEFAULT_STRING
+ CC
+@@ -1740,8 +1741,6 @@ Optional Packages:
+   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+   --with-odoc             build documentation with odoc
+-  --with-target-bindir    location of the runtime binaries on the target
+-                          system
+   --with-target-sh        location of Posix sh on the target system
+   --with-afl              use the AFL fuzzer
+   --with-flexdll          bootstrap FlexDLL from the given sources
+@@ -1777,6 +1776,8 @@ Some influential environment variables:
+               libunwind headers>)
+   LIBUNWIND_LDFLAGS
+               linker flags for libunwind (e.g. -L<location of libunwind>
++  TARGET_BINDIR
++              location of the runtime binaries on the target system
+   WINDOWS_UNICODE_MODE
+               how to handle Unicode under Windows: ansi, compatible
+   DEFAULT_STRING
+@@ -4085,14 +4086,6 @@ fi
+ 
+ 
+ 
+-# Check whether --with-target-bindir was given.
+-if test ${with_target_bindir+y}
+-then :
+-  withval=$with_target_bindir; target_bindir=$withval
+-else $as_nop
+-  target_bindir=''
+-fi
+-
+ 
+ 
+ # Check whether --with-target-sh was given.
+@@ -22677,9 +22670,9 @@ fi
+   eval "exec_prefix=\"$exec_prefix\""
+   eval "ocaml_bindir=\"$bindir\""
+   eval "ocaml_libdir=\"$libdir\""
+-  if test x"$target_bindir" = 'x'
++  if test x"$TARGET_BINDIR" = 'x'
+ then :
+-  target_bindir="$ocaml_bindir"
++  TARGET_BINDIR="$ocaml_bindir"
+ fi
+   if test x"$target_launch_method" = 'x'
+ then :
+@@ -23642,7 +23635,7 @@ fi
+   target_launch_method=\
+ '$(echo "$target_launch_method" | sed -e "s/'/'\"'\"'/g")'
+   ocaml_bindir='$(echo "$ocaml_bindir" | sed -e "s/'/'\"'\"'/g")'
+-  target_bindir='$(echo "$target_bindir" | sed -e "s/'/'\"'\"'/g")'
++  TARGET_BINDIR='$(echo "$TARGET_BINDIR" | sed -e "s/'/'\"'\"'/g")'
+ 
+ _ACEOF
+ 
+@@ -24813,7 +24806,7 @@ ltmain=$ac_aux_dir/ltmain.sh
+  ;;
+     "shebang":C) printf '%s\n%s\000\n' "$launch_method" "$ocaml_bindir" \
+     > stdlib/runtime.info
+-  printf '%s\n%s\000\n' "$target_launch_method" "$target_bindir" \
++  printf '%s\n%s\000\n' "$target_launch_method" "$TARGET_BINDIR" \
+     > stdlib/target_runtime.info ;;
+ 
+   esac
 diff --git a/configure.ac b/configure.ac
 index 7e3b3a054e..bb661f9f6a 100644
 --- a/configure.ac

--- a/patches/5.3.0/0006-Add-a-configurable-library-directory-on-target.patch
+++ b/patches/5.3.0/0006-Add-a-configurable-library-directory-on-target.patch
@@ -52,18 +52,64 @@ index e432851cde..522c0f6338 100644
  STUBLIBDIR=@libdir@/stublibs
  
 diff --git a/configure b/configure
-index b9cd0229890350b736c804eaa7cc97a9e8910aef..21a2617e3958bd64ddfc1fb914d1c6c9b9fed1dc 100755
-GIT binary patch
-delta 252
-zcmX@zsC}?mdqYehZ-`@%yK6|ikEfH1XVB*8K!1KNgwW<?35FR+{K>s1lvr{ylZqzq
-zIw9q*qfnBskd&%WTAZ4qkd|M>rGNrbD)VwO^RlfKQc}|rOLIz!LCQ-qQWeS)b4pVc
-z^3xQ6CZ%K+ZN75i@TTq4su^94r;Fz^Nw$Al#|XqsK+FupEI`Z(#B4y!zWviWjtj4h
-p5iSHeT1mlHp@Iu&aGrt{&<QAVwn{1xOO)C-&E(v^X(pGXIsjQ~TZ;ey
-
-delta 79
-zcmX@utbMvsdqYg%=Bz+J{>{e{bTc-$pFFT>yGIS9i}7@p?Tq5>OV=|3F%u9o12GE_
-cvjQ<25VLPzx}M|0tM(nUIJfVZ#l@)(0Ik*}S^xk5
-
+index b9cd022989..21a2617e39 100755
+--- a/configure
++++ b/configure
+@@ -796,6 +796,7 @@ build_cpu
+ build
+ ar_supports_response_files
+ QS
++TARGET_LIBDIR
+ ocaml_libdir
+ ocaml_bindir
+ compute_deps
+@@ -1055,6 +1056,7 @@ DLLIBS
+ LIBUNWIND_CPPFLAGS
+ LIBUNWIND_LDFLAGS
+ TARGET_BINDIR
++TARGET_LIBDIR
+ WINDOWS_UNICODE_MODE
+ DEFAULT_STRING
+ CC
+@@ -1778,6 +1780,9 @@ Some influential environment variables:
+               linker flags for libunwind (e.g. -L<location of libunwind>
+   TARGET_BINDIR
+               location of the runtime binaries on the target system
++  TARGET_LIBDIR
++              location of the libraries on the target system, to be used for
++              dynlink; defaults to the value of libdir
+   WINDOWS_UNICODE_MODE
+               how to handle Unicode under Windows: ansi, compatible
+   DEFAULT_STRING
+@@ -3531,6 +3536,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
+ 
+ 
+ 
++
+ 
+ 
+ ## Generated files
+@@ -4088,6 +4094,8 @@ fi
+ 
+ 
+ 
++
++
+ # Check whether --with-target-sh was given.
+ if test ${with_target_sh+y}
+ then :
+@@ -22452,6 +22460,11 @@ then :
+   libdir="$libdir"/ocaml
+ fi
+ 
++if test x"$TARGET_LIBDIR" = x
++then :
++  TARGET_LIBDIR="$libdir"
++fi
++
+ if test x"$mandir" = x'${datarootdir}/man'
+ then :
+   mandir='${prefix}/man'
 diff --git a/configure.ac b/configure.ac
 index bb661f9f6a..9b0331cdee 100644
 --- a/configure.ac

--- a/patches/5.3.0/0007-Detect-flexlink-only-on-relevant-targets.patch
+++ b/patches/5.3.0/0007-Detect-flexlink-only-on-relevant-targets.patch
@@ -13,16 +13,32 @@ non-cross compiler
  2 files changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 21a2617e3958bd64ddfc1fb914d1c6c9b9fed1dc..8e8f2351c65874ed71a60f10a88584157cb6b08a 100755
-GIT binary patch
-delta 75
-zcmX@utUbR)yP<`#g{g(Pg{6gc3!C4?=`PZ2;?paH*?6Ygo@P^=u4cm~yFL3NTOiAH
-dp~;Lg)0G~x3AbOo$_B*jK+LiI;#JNMuL0Y&9UK4v
-
-delta 55
-zcmbQ=qJ6MgyP<`#g{g(Pg{6gc3!C4?=`J4`Ww)=t$QH;l{mv6M<#yX^Y(UHo#2njg
-JuW>$l4FF~P7dZd`
-
+index 21a2617e39..8e8f2351c6 100755
+--- a/configure
++++ b/configure
+@@ -15649,7 +15649,9 @@ fi ;;
+ esac
+ fi
+ 
+-  # Extract the first word of "flexlink", so it can be a program name with args.
++  case $target in #(
++  *-*-cygwin*|*-w64-mingw32*|*-pc-windows) :
++    # Extract the first word of "flexlink", so it can be a program name with args.
+ set dummy flexlink; ac_word=$2
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+ printf %s "checking for $ac_word... " >&6; }
+@@ -15690,7 +15692,10 @@ else
+ printf "%s\n" "no" >&6; }
+ fi
+ 
+-
++ ;; #(
++  *) :
++     ;;
++esac
+ 
+   if test -n "$flexlink" && test -z "$flexdll_source_dir"
+ then :
 diff --git a/configure.ac b/configure.ac
 index 9b0331cdee..ea5fa86609 100644
 --- a/configure.ac

--- a/patches/5.3.0/0013-Detect-the-need-for-the-GNU-note-for-non-executable-.patch
+++ b/patches/5.3.0/0013-Detect-the-need-for-the-GNU-note-for-non-executable-.patch
@@ -56,24 +56,84 @@ index b17e11d511..9c6feb1034 100644
    AC_CACHE_CHECK([whether $CC supports the labels as values extension],
      [ocaml_cv_prog_cc_labels_as_values],
 diff --git a/configure b/configure
-index 8e8f2351c65874ed71a60f10a88584157cb6b08a..1735c1178d1f8c7c322f108c4f0207e6ff2576a1 100755
-GIT binary patch
-delta 669
-zcmbQ=qJ3ea_6CVCvGUB4jQG6#ywr-+<l>UV<ZK|PB(+&QtX({e5r~<9m>Gy!wu^_c
-zPVJn&`39@y^xRZ-c7^oRywsw^lGI{_L<K#NCOvn*P+hPY3dO0(CDR4_*=46Y=(DgW
-zJ3A9r9oNsUEr{We=?kATnr#1@z^TGmAD*gEUX)pqs!)=Vs*qS*oSK`IQ>l=dSCS7F
-z(NjrGj?YiZO06hSNXyItDN%5Aj(7I=4e<1FjrVkO^$B+6QUC&FknYl4kjwKFQj3c6
-zixe``6pBleGk{(JYfZ^dEzVOfQAn-GEG|(<Oe;w(Qs7F?&n?Kz$;?aVn$9T3DZ->1
-zJY7GAQ&J0TW`1&FZcco1S$siJetLXzGG>_C=H*Xc_?g{vI&&JQp(M~k6*u=F*8ude
-zn||;Ylj!6IQ<3S*Ca?=)36b-qtgh1yS~-NK2mE4XnJ${ieq(xbE2Gu)&WY@T0_Y()
-z{h=AV`1AunDJgWRR3!yFH8X34TCV9YC$h`)qsdR-=+7a7BYjN&5Y3?|7Va715%1^k
-z=NjSa930~4><#3ExK3aHj$Kg!d%ChsOUx-w<x0!sn*Kn5O|*UgeO4f517da{=Geaf
-IK4-!s0JReFT>t<8
-
-delta 61
-zcmcaGQG0%i_6CWtX8o{s{V+x#W&&bnAZFRFAI3VRbNXa)HsSVyXRJWX2E^<@%(1=T
-I8E3*H0JA6;*#H0l
-
+index 8e8f2351c6..1735c1178d 100755
+--- a/configure
++++ b/configure
+@@ -874,6 +874,7 @@ flexdll_dir
+ bootstrapping_flexdll
+ flexdll_source_dir
+ zstd_libs
++with_nonexecstack_note
+ native_ldflags
+ cclibs
+ oc_dll_ldflags
+@@ -13538,6 +13539,66 @@ CC=$lt_save_CC
+ CFLAGS="$saved_CFLAGS"
+ target_os=$old_host_os
+ 
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC generates a .note.GNU-stack section" >&5
++printf %s "checking if $CC generates a .note.GNU-stack section... " >&6; }
++if test ${ocaml_cv_prog_cc_nonexecstack_note+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++
++  saved_CC="$CC"
++  saved_CFLAGS="$CFLAGS"
++  saved_CPPFLAGS="$CPPFLAGS"
++  saved_LIBS="$LIBS"
++  saved_ac_ext="$ac_ext"
++  saved_ac_compile="$ac_compile"
++  # Move the content of confdefs.h to another file so it does not
++  # get included
++  mv confdefs.h confdefs.h.bak
++  touch confdefs.h
++
++
++    # We write the assembly into the .$ac_objext file as AC_COMPILE_IFELSE
++    # assumes an error if such a file doesn't exist after compiling
++    CFLAGS="$CFLAGS -S -o conftest.$ac_objext"
++
++    ocaml_cv_prog_cc_nonexecstack_note=no
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++  if $FGREP .note.GNU-stack conftest.$ac_objext >/dev/null
++then :
++  ocaml_cv_prog_cc_nonexecstack_note=yes
++fi
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++
++  # Restore the content of confdefs.h
++  mv confdefs.h.bak confdefs.h
++  ac_compile="$saved_ac_compile"
++  ac_ext="$saved_ac_ext"
++  CPPFLAGS="$saved_CPPFLAGS"
++  CFLAGS="$saved_CFLAGS"
++  CC="$saved_CC"
++  LIBS="$saved_LIBS"
++
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_cc_nonexecstack_note" >&5
++printf "%s\n" "$ocaml_cv_prog_cc_nonexecstack_note" >&6; }
++
++  if test "x$ocaml_cv_prog_cc_nonexecstack_note" = xyes
++then :
++  with_nonexecstack_note=true
++    printf "%s\n" "#define WITH_NONEXECSTACK_NOTE 1" >>confdefs.h
++
++else $as_nop
++  with_nonexecstack_note=false
++fi
++
++
+ case $host in #(
+   sparc-sun-solaris*) :
+     DEP_CC="false" ;; #(
 diff --git a/configure.ac b/configure.ac
 index ea5fa86609..6cf1dbe353 100644
 --- a/configure.ac

--- a/patches/5.3.0/0016-Detect-support-for-.size-and-.type-assembler-directi.patch
+++ b/patches/5.3.0/0016-Detect-support-for-.size-and-.type-assembler-directi.patch
@@ -79,29 +79,130 @@ index 9c6feb1034..daf2f0ce5e 100644
    AC_CACHE_CHECK([whether $CC supports the labels as values extension],
      [ocaml_cv_prog_cc_labels_as_values],
 diff --git a/configure b/configure
-index 1735c1178d1f8c7c322f108c4f0207e6ff2576a1..d7921b85866b3adb0de8a9469b5a3d0966c1516b 100755
-GIT binary patch
-delta 1614
-zcmbW1&rcIU6vtC^3*C!p1Oesn0w|OpO(YFOn;MNaSPupZ(P#|YWp~;RZf7>TTM&ix
-zU<?OOjfwLwn3x!D^-8=Oxq4AVIpD>+#`tziTiUb&Hhp`TnfICZzVFTZSRDQIdUWGw
-z^0ZB#5XD(BiK0`BXbxQ>&-Rj~y`*nAB!a8H+w1eIKD0Kp6KE$(^Q+PyD&BvVZuNy-
-zZ%~;IVHW|aor4NSZ2k84iK}0v;33C^zgL7_wFi69TWJ!GEw*0xBBi&Pz@Sh3+Lk_?
-zYjrTjxG2&<;u>WRq>1V%I&m;3g)b~d<;KNyo@v8Noa!NXDg#)=$y*E}6H$3h7TfQn
-zZjrjw)>puwJb92&lL&7@7x(AJ;_bV*RtLPSS{)dGdjxb2j5}a({s_|C0u{>I>V-;G
-zyk#d#00Y6C@M542P}}v}k7WQdgb_=1hz^v2lT{tCY0fkVXsS&-0%f+NGL68(3Ld}>
-zo-?UItSZ9f%fvFZ$%sM54a!pa$Kx56AJ1qST#SS#U^z>*ERY;^FaU%RRmTp1uz{pn
-z^~pYureSb88J~fnhhB?>M;hufB#HrFmw3J-bxv2ctk-&l*m9a43FvBkfOxY?Y!JUC
-z(ydf|j19;_wfX*q^yD6_-d>l_SZ%!?QQm0MD{e6dhEV_vyD)|y*FtdFlZ0z(&QP=^
-z#k6=v(KMwRVEwDMW9S6YXqm+LnD;+6Wfoh%N*Ot}dkhQ2nP%i|95l$0iLGj4dohqK
-zb$*l1`_43v{^gw?JtFm83fAOr$gUr*T$qf)nv9~9)jzT@2j#6K)I1Dg3(f*VowJDt
-zab@oQOkBB<NXD<vCGN&&g_`U*+t2u+gw37y9`R<kV`?hR^Ef)GtB6hUCE?Vvh@Cg^
-zWw|q;ak^F}D~i!8Ha6Q%8UG0&wyV}ebj@p^R;k9)s)0jezechscKf^5&0Pu2kJgUX
-LQ8IS}sjq(lgNZ_^
-
-delta 67
-zcmcb$Li@r*?F}D-nmL2Fa|SaiX-?OvVf1aUs$m3TCLm@8VwUYyHLQO#+n;@81!6WJ
-PW(Q)9?aw}PmOKIg)T$qh
-
+index 1735c1178d..d7921b8586 100755
+--- a/configure
++++ b/configure
+@@ -823,6 +823,7 @@ mkdll_exp
+ mkdll
+ rpath
+ sharedlib_cflags
++asm_size_type_directives
+ asm_cfi_supported
+ AS
+ endianness
+@@ -3490,6 +3491,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
+ 
+ 
+ 
++
+ 
+ 
+  # TODO: rename this variable
+@@ -3538,6 +3540,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
+ 
+ 
+ 
++
+ 
+ 
+ ## Generated files
+@@ -13598,6 +13601,96 @@ else $as_nop
+   with_nonexecstack_note=false
+ fi
+ 
++  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC generates .size and .type asm directives" >&5
++printf %s "checking if $CC generates .size and .type asm directives... " >&6; }
++if test ${ocaml_cv_prog_cc_asm_size_type_directives+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++
++  saved_CC="$CC"
++  saved_CFLAGS="$CFLAGS"
++  saved_CPPFLAGS="$CPPFLAGS"
++  saved_LIBS="$LIBS"
++  saved_ac_ext="$ac_ext"
++  saved_ac_compile="$ac_compile"
++  # Move the content of confdefs.h to another file so it does not
++  # get included
++  mv confdefs.h confdefs.h.bak
++  touch confdefs.h
++
++
++    # We write the assembly into the .$ac_objext file as AC_COMPILE_IFELSE
++    # assumes an error if such a file doesn't exist after compiling
++    CFLAGS="$CFLAGS -S -o conftest.$ac_objext"
++
++    ocaml_cv_prog_cc_asm_size_type_directives=no
++    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int feat_detect_obj;
++int feat_detect_func(void) {
++  return 42;
++}
++
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"
++then :
++  asm_type_obj_directive=no
++      asm_type_func_directive=no
++      asm_size_func_directive=no
++      # We do not look for a .size directive for the object as it is not
++      # generated in that simple case for instance by the compiler
++      # powerpc64le-linux-gnu-gcc 14.2 which emits instead an .lcomm directive
++      if $GREP '\.type.*feat_detect_obj' conftest.$ac_objext >/dev/null
++then :
++  asm_type_obj_directive=yes
++fi
++      if $GREP '\.type.*feat_detect_func' conftest.$ac_objext >/dev/null
++then :
++  asm_type_func_directive=yes
++fi
++      if $GREP '\.size.*feat_detect_func' conftest.$ac_objext >/dev/null
++then :
++  asm_size_func_directive=yes
++fi
++      case $asm_type_obj_directive,$asm_type_func_directive,$asm_size_func_directive in #(
++  yes,yes,yes) :
++    ocaml_cv_prog_cc_asm_size_type_directives=yes ;; #(
++  no,no,no) :
++    ocaml_cv_prog_cc_asm_size_type_directives=no ;; #(
++  *) :
++    ocaml_cv_prog_cc_asm_size_type_directives=unconclusive ;;
++esac
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
++
++  # Restore the content of confdefs.h
++  mv confdefs.h.bak confdefs.h
++  ac_compile="$saved_ac_compile"
++  ac_ext="$saved_ac_ext"
++  CPPFLAGS="$saved_CPPFLAGS"
++  CFLAGS="$saved_CFLAGS"
++  CC="$saved_CC"
++  LIBS="$saved_LIBS"
++
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_cc_asm_size_type_directives" >&5
++printf "%s\n" "$ocaml_cv_prog_cc_asm_size_type_directives" >&6; }
++
++  case $ocaml_cv_prog_cc_asm_size_type_directives in #(
++  yes) :
++    asm_size_type_directives=true
++      printf "%s\n" "#define ASM_SIZE_TYPE_DIRECTIVES 1" >>confdefs.h
++ ;; #(
++  no) :
++    asm_size_type_directives=false ;; #(
++  *) :
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: found inconsistent results for .size and .type directives" >&5
++printf "%s\n" "$as_me: WARNING: found inconsistent results for .size and .type directives" >&2;}
++    asm_size_type_directives=false ;;
++esac
++
+ 
+ case $host in #(
+   sparc-sun-solaris*) :
 diff --git a/configure.ac b/configure.ac
 index 6cf1dbe353..e1f2e85610 100644
 --- a/configure.ac

--- a/patches/5.3.0/0019-Accept-native-freestanding-targets-at-configure-time.patch
+++ b/patches/5.3.0/0019-Accept-native-freestanding-targets-at-configure-time.patch
@@ -14,19 +14,39 @@ Set `system` to `none` and `os_type` to `None` in such cases
  2 files changed, 16 insertions(+), 2 deletions(-)
 
 diff --git a/configure b/configure
-index d7921b85866b3adb0de8a9469b5a3d0966c1516b..e4efe90505bfeba237bce9057e33f6924fd4ed28 100755
-GIT binary patch
-delta 444
-zcmcb$LVNl;?S>Y{7N!>F7M2#)7Pc+yr`a`hv~;y}^YZgjYqY@3)SNUeO$9411t7>T
-zE~zX?wN>&1N>3N;WtZ80hn;=<>gng#uydIv7A0qxnZPtB7Ud#w;Bp|-YG86e&h&p9
-z*-eZ=)+tz9D=2FKttrSaPc14)HZ#ddg*ydJ45X27BfHvk&lT*l`q*`2>II1)>l8Aw
-zRw%A4E=kR`MKPi%vpBg7;dlfWuDNhCyR15jo?>H5g9^Bna2{L--%55#R2>x-X7LD1
-i;5?`f6IPJ%T+<J-v&*z^*vt;Z96-#ueZyw1RSEzq=Z!4@
-
-delta 62
-zcmbQfPW#ph?S>Y{7N!>F7M2#)7Pc+yr`f01++-Kn&d0&NWA${!A`ao{4OiK?+H<$D
-Q12G2>b8gSw#<fZT0N_s-mjD0&
-
+index d7921b8586..e4efe90505 100755
+--- a/configure
++++ b/configure
+@@ -16145,6 +16145,8 @@ esac
+  ;; #(
+   gcc-*,powerpc-*-linux*) :
+     oc_ldflags="-mbss-plt" ;; #(
++  *,*-*-none|*,*-*-elf*) :
++    ostype="None" ;; #(
+   *) :
+      ;;
+ esac
+@@ -17761,7 +17763,19 @@ fi ;; #(
+   x86_64-*-cygwin*) :
+     has_native_backend=yes; arch=amd64; system=cygwin ;; #(
+   riscv64-*-linux*) :
+-    has_native_backend=yes; arch=riscv; model=riscv64; system=linux
++    has_native_backend=yes; arch=riscv; model=riscv64; system=linux ;; #(
++  aarch64-*-none|arm64-*-none|aarch64-*-elf*|arm64-*-elf*) :
++    has_native_backend=yes; arch=arm64; system=none ;; #(
++  powerpc64le*-*-none|powerpc64le*-*-elf*) :
++    has_native_backend=yes; arch=power; model=ppc64le; system=none ;; #(
++  powerpc64*-*-none|powerpc64*-*-elf*) :
++    has_native_backend=yes; arch=power; model=ppc64; system=none ;; #(
++  riscv64-*-none|riscv64-*-elf*) :
++    has_native_backend=yes; arch=riscv; model=riscv64; system=none ;; #(
++  s390x*-*-none|s390x*-*-elf*) :
++    has_native_backend=yes; arch=s390x; model=z10; system=none ;; #(
++  x86_64-*-none|x86_64-*-elf*) :
++    has_native_backend=yes; arch=amd64; system=none
+  ;; #(
+   *) :
+      ;;
 diff --git a/configure.ac b/configure.ac
 index e1f2e85610..04d31b4962 100644
 --- a/configure.ac

--- a/patches/5.3.0/0020-Allow-ocaml-in-a-triplet-target-to-build-freestandin.patch
+++ b/patches/5.3.0/0020-Allow-ocaml-in-a-triplet-target-to-build-freestandin.patch
@@ -18,21 +18,39 @@ targets
  2 files changed, 13 insertions(+)
 
 diff --git a/configure b/configure
-index e4efe90505bfeba237bce9057e33f6924fd4ed28..c11e7ad19c318385e30455286cbc53d285786ef7 100755
-GIT binary patch
-delta 532
-zcmZ8du}(rU6wOl*eIu*O^+AGy&%wpSh>45F(a27&<pNDgOWGnD2izQ3nB*@^OpJV;
-ziMQ_&6o%9Gp0?+nbLSt8pU=kYSJawLDsZKg8AD<O4pai(zyra^Q3ue0?-M9=9)uYT
-zjVA5EbTihY?U4s><xuf1H3)PRS71zlHYiBl0|YU0-V9jQDA7lL)-{&tt|f9F^`sM?
-z<zgq$GSD&L%yDSJTANMS5U~%7R;p*PG`7-v(!q3cfmZY{Q_U{36v6Sx(^5$wUr2#!
-zsTn(bq_)RNNYO?m(KVB5-Y+kcI0S+<F2t-H#sKxSo@N6(f^#kbP_#3}+w1#gm6wbR
-zMJ=smXU9W&T2~7^C(Q=AvT&LwSpBd5Q=Z>_m-gr7_vmafoklN(gN?t-On;G*x8f{f
-YY%#VO1xAsv!zeL!8GDQ3EH2;t0=9m!@c;k-
-
-delta 64
-zcmeynQG5D2?S?IkA>GsWv@@D-_wQw_W@&#jkr9ZQfS4JGL3~yqW&>h&Am#vK&h2j|
-IatXQv0N^JcY5)KL
-
+index e4efe90505..c11e7ad19c 100755
+--- a/configure
++++ b/configure
+@@ -3677,6 +3677,21 @@ IFS=$ac_save_IFS
+ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+ 
+ 
++# Allow "ocaml" to be used as the last component of the target triplet in case
++# we are using a custom toolchain for a freestanding target. To do so, the
++# target triplet is temporarily rewritten to "<arch>-none" to compute the
++# canonical target
++save_target_alias="$target_alias"
++case $target_alias in #(
++  *-*-ocaml) :
++    ac_save_IFS=$IFS
++    IFS='-'
++    set x $target_alias
++    target_alias="$2-none"
++    IFS=$ac_save_IFS ;; #(
++  *) :
++     ;;
++esac
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking target system type" >&5
+ printf %s "checking target system type... " >&6; }
+ if test ${ac_cv_target+y}
+@@ -3717,6 +3732,7 @@ test -n "$target_alias" &&
+   test "$program_prefix$program_suffix$program_transform_name" = \
+     NONENONEs,x,x, &&
+   program_prefix=${target_alias}-
++target_alias="$save_target_alias"
+ 
+ # Override cross_compiling and ac_tool_prefix variables since the C toolchain is
+ # used to generate target code when building a cross compiler
 diff --git a/configure.ac b/configure.ac
 index 04d31b4962..6d0d1be9c0 100644
 --- a/configure.ac


### PR DESCRIPTION
This PR is a draft, in the sense that it’s probably not meant to be merged as is, as it is more of a prototype than a finished version. But it would address #151.

This PR adds an `opatch` command that uses the `patch` library and is largely extracted from opam (so kudos to the original authors there!). I think it is of more general use than just `ocaml-solo5` (at least `ocaml-unikraft` is of interest here :-)) so it might be nice to push it into another repository, maybe `patch` itself if the command is good enough. I’ve cut a few corners as not everything was actually useful for our use case (in particular to delete directories that end up empty after patching).

As half of `opatch` is extracted from opam, it inherits its LGPL license; if we want to relicense it under ISC like `patch`, we would need the original authors’ agreement (`apply` is mostly @kit-ty-kate’s code, if I’m not mistaken; `realpath` has more history) or rewrite them.